### PR TITLE
Amended references to 'get_query_set()'

### DIFF
--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -13,8 +13,8 @@ class PublishedManager(models.Manager):
         super(PublishedManager, self).__init__()
         self.is_published = is_published
 
-    def get_query_set(self):
-        return super(PublishedManager, self).get_query_set().filter(
+    def get_queryset(self):
+        return super(PublishedManager, self).get_queryset().filter(
             is_published=self.is_published)
 
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.7/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset
