### PR TITLE
Specify a range of usable versions for django-reversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIREMENTS = [
     'django-appdata',
     'django-cms',
     'aldryn-people',
-    'django-reversion',
+    'django-reversion>=1.8.2,<1.9',
     'django>=1.6,<1.7',
 ]
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -19,4 +19,4 @@ django-filer
 aldryn-common
 django-appdata
 aldryn-people
-django-reversion
+django-reversion>=1.8.2,<1.9


### PR DESCRIPTION
Can we specify some other requirements at this point? If not, I'll marge this as is now. This actually addresses #14
