### PR TITLE
Use very simple template instead of title concatination in a list view

### DIFF
--- a/aldryn_newsblog/templates/aldryn_newsblog/article_list.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/article_list.html
@@ -1,0 +1,3 @@
+{% for article in article_list %}
+    {{ article.title }}
+{% endfor %}

--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -19,10 +19,6 @@ class ArticleList(AppConfigMixin, ListView):
     def queryset(self):
         return Article.objects.filter(namespace__namespace=self.namespace)
 
-    def get(self, request):
-        return HttpResponse('\n'.join(
-            article.title for article in self.queryset))
-
 
 class AuthorArticleList(ArticleList):
     """A list of articles written by a specific author."""


### PR DESCRIPTION
This allows at least to override template in the project and not to wait until a flexible templates for this app will be available. aldryn-blog templates are just to feature-rich to use them with minimal changes.
