### PR TITLE
Use helper runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 sudo: false
 
 env:
-  - CMD=./test
+  - CMD="python setup.py test"
 
 python:
   - 2.7

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     classifiers=CLASSIFIERS,
     include_package_data=True,
     zip_safe=False,
+    test_suite="test_settings.run",
     dependency_links=[
         'git+https://github.com/yakky/django-cms@future/integration#egg=django-cms-3.0.90a3',
         'git+https://github.com/aldryn/aldryn-apphooks-config#egg=aldryn-apphooks-config-0.1.0',

--- a/test
+++ b/test
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-djangocms-helper aldryn_newsblog test --cms --extra-settings=test_settings $@

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ aldryn-people
 dj-database-url
 django-appdata
 django-classy-tags
--e git+http://github.com/yakky/django-cms/@feature/appspaced_apphooks#egg=django-cms
+-e git+http://github.com/yakky/django-cms@future/integration#egg=django-cms
 django-filer
 django-mptt
 django-parler
@@ -15,7 +15,7 @@ django-taggit
 django-treebeard>=2.0
 django>=1.6,<1.7
 djangocms-admin-style
-djangocms-helper
+djangocms-helper>=0.7
 djangocms_text_ckeditor
 docopt
 flake8

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 HELPER_SETTINGS = {
     'TIME_ZONE': 'Europe/Zurich',
     'LANGUAGES': (
@@ -13,7 +16,16 @@ HELPER_SETTINGS = {
         'aldryn_people',
         'filer',
         'djangocms_text_ckeditor',
+        'parler',
     ],
     # app-specific
     'ALDRYN_NEWSBLOG_PAGINATE_BY': 10,
 }
+
+
+def run():
+    from djangocms_helper import runner
+    runner.cms('aldryn_newsblog')
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Demonstrates how to use the djangocms-helper runner in the helper settings file and adds it as test suite to use `python setup.py test` to run tests
