### PR TITLE
Alternative layout for config classes

### DIFF
--- a/aldryn_newsblog/cms_appconfig.py
+++ b/aldryn_newsblog/cms_appconfig.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from aldryn_apphooks_config.utils import setup_config
+from aldryn_apphooks_config.models import AppHookConfig
+from app_data import AppDataForm
+from parler.models import TranslatableModel
+from parler.models import TranslatedFields
+
+
+class NewsBlogConfig(TranslatableModel, AppHookConfig):
+    """Adds some translatable, per-app-instance fields."""
+    translations = TranslatedFields(
+        app_title=models.CharField(_('application title'), max_length=234),
+    )
+
+
+class NewsBlogConfigForm(AppDataForm):
+    pass
+setup_config(NewsBlogConfigForm, NewsBlogConfig)

--- a/aldryn_newsblog/forms.py
+++ b/aldryn_newsblog/forms.py
@@ -1,17 +1,6 @@
 from django import forms
-from app_data import AppDataForm
-
-from aldryn_apphooks_config.utils import setup_config
-
-from .models import NewsBlogConfig
 
 
 class LatestEntriesForm(forms.ModelForm):
     pass
 
-
-class NewsBlogConfigForm(AppDataForm):
-    pass
-
-
-setup_config(NewsBlogConfigForm, NewsBlogConfig)

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -16,11 +16,11 @@ from cms.models.pluginmodel import CMSPlugin
 from aldryn_people.models import Person
 from filer.fields.image import FilerImageField
 from parler.models import TranslatableModel, TranslatedFields
-from aldryn_apphooks_config.models import AppHookConfig
 from aldryn_categories.fields import CategoryManyToManyField
 from taggit.managers import TaggableManager
 from djangocms_text_ckeditor.fields import HTMLField
 
+from .cms_appconfig import NewsBlogConfig
 from .versioning import version_controlled_content
 from .managers import RelatedManager
 
@@ -32,13 +32,6 @@ elif settings.LANGUAGE:
 else:
     raise ImproperlyConfigured(
         'Neither LANGUAGES nor LANGUAGE was found in settings.')
-
-
-class NewsBlogConfig(TranslatableModel, AppHookConfig):
-    """Adds some translatable, per-app-instance fields."""
-    translations = TranslatedFields(
-        app_title=models.CharField(_('application title'), max_length=234),
-    )
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
How about moving the config model and form in the same module name ``cms_appconfig.py``
For the form registration at https://github.com/aldryn/aldryn-newsblog/compare/feature/layout_proposal?expand=1#diff-e09ca64b10cf86fedb011f0c7e56cd6bR21 to work, the module containing ``setup_config`` call **must** be imported.
With the current layout model and form are splitted in two different modules, leading to potential circular dependencies.
Moving them to a dedicated module which is imported by the ``models.py`` should be a better layout as the config module is always imported with no risk of circular imports