### PR TITLE
Coverage: fine-tune setup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+branch = True
+source = aldryn_newsblog
+omit =
+    aldryn_newsblog/south_migrations/*
+    aldryn_newsblog/migrations/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cms/django
 *.svn
 .*
 !.travis.yml
+!.coveragerc
 *.xml
 /*env*/
 *.sqlite


### PR DESCRIPTION
 - cover only aldryn_newsblog directory
 - exclude migrations
 - enable branch coverage
 - do not include common debug and special code branches in reports