### PR TITLE
Allow to disable automatic author (Person object) creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,13 @@ Manual Installation
 
 4) (Re-)Start your application server.
 
+Available settings
+------------------
+
+ * ``ALDRYN_NEWSBLOG_CREATE_AUTHOR`` - if set to ``False``, no author (Person
+   object) would be implicitly created. Default value: ``True``.
+ * ``ALDRYN_NEWSBLOG_PAGINATE_BY`` - the number of objects to show per page.
+   Default value: ``10``.
 
 Notes
 -----

--- a/README.rst
+++ b/README.rst
@@ -73,8 +73,6 @@ Available settings
 
  * ``ALDRYN_NEWSBLOG_CREATE_AUTHOR`` - if set to ``False``, no author (Person
    object) would be implicitly created. Default value: ``True``.
- * ``ALDRYN_NEWSBLOG_PAGINATE_BY`` - the number of objects to show per page.
-   Default value: ``10``.
 
 Notes
 -----

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -99,14 +99,17 @@ class Article(TranslatableModel):
         return slug
 
     def save(self, *args, **kwargs):
-        # Ensure there is an owner.
-        if self.author is None:
-            self.author = Person.objects.get_or_create(
-                user=self.owner,
-                defaults={
-                    'name': u' '.join((self.owner.first_name,
-                                       self.owner.last_name))
-                })[0]
+        create_author = getattr(
+            settings, 'ALDRYN_NEWSBLOG_CREATE_AUTHOR', True)
+        if create_author:
+            # Ensure there is an owner.
+            if self.author is None:
+                self.author = Person.objects.get_or_create(
+                    user=self.owner,
+                    defaults={
+                        'name': u' '.join((self.owner.first_name,
+                                           self.owner.last_name))
+                    })[0]
 
         # Start with a naïve approach, if none provided.
         if not self.slug:

--- a/aldryn_newsblog/tests/test_aldryn_newsblog.py
+++ b/aldryn_newsblog/tests/test_aldryn_newsblog.py
@@ -61,12 +61,16 @@ class NewsBlogTestsMixin(CategoryTestCaseMixin):
             author = kwargs['author']
         except KeyError:
             author = self.create_person()
+        try:
+            owner = kwargs['owner']
+        except KeyError:
+            owner = author.user
 
         fields = {
             'title': rand_str(),
             'slug': rand_str(),
             'author': author,
-            'owner': author.user,
+            'owner': owner,
             'app_config': self.app_config,
             'publishing_date': datetime.now(),
             'is_published': True,
@@ -546,6 +550,11 @@ class TestAldrynNewsBlog(NewsBlogTestsMixin, TransactionTestCase):
             app_config=self.app_config, publishing_date=datetime.now())
         article.save()
         self.assertEquals(article.author.user, article.owner)
+        with self.settings(ALDRYN_NEWSBLOG_CREATE_AUTHOR=False):
+            article = Article.objects.create(
+                title=rand_str(), owner=author.user,
+                app_config=self.app_config, publishing_date=datetime.now())
+        self.assertEquals(article.author, None)
 
     def test_auto_new_author(self):
         user = self.create_user()

--- a/aldryn_newsblog/tests/test_aldryn_newsblog.py
+++ b/aldryn_newsblog/tests/test_aldryn_newsblog.py
@@ -61,16 +61,12 @@ class NewsBlogTestsMixin(CategoryTestCaseMixin):
             author = kwargs['author']
         except KeyError:
             author = self.create_person()
-        try:
-            owner = kwargs['owner']
-        except KeyError:
-            owner = author.user
 
         fields = {
             'title': rand_str(),
             'slug': rand_str(),
             'author': author,
-            'owner': owner,
+            'owner': author.user,
             'app_config': self.app_config,
             'publishing_date': datetime.now(),
             'is_published': True,


### PR DESCRIPTION
ALDRYN_NEWSBLOG_CREATE_AUTHOR is set to True by default to keep backwards compatible behaviour.
Fixes #64