### PR TITLE
Rename plugins, use 'articles' rather than 'entries' throughout.

### DIFF
--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/archive.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/archive.html
@@ -16,7 +16,7 @@
                     <a href="{% namespace_url 'article-list-by-month' year=year.grouper month=month.date|date:"n" namespace=instance.app_config.namespace %}"
                         class="list-group-item{% if year.grouper == current_year and month.date.month == current_month %} active{% endif %}">
                         {{ month.date|date:"F" }}
-                        <span class="badge">{{ month.num_entries }}</span>
+                        <span class="badge">{{ month.num_articles }}</span>
                     </a>
                 {% endfor %}
             </div>

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/featured_articles.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/featured_articles.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="aldryn aldryn-newsblog aldryn-newsblog-entries aldryn-newsblog-entries-featured">
+<div class="aldryn aldryn-newsblog aldryn-newsblog-articles aldryn-newsblog-articles-featured">
     {% for article in instance.get_articles %}
         {% include "aldryn_newsblog/includes/article.html" %}
     {% endfor %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/latest_articles.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/latest_articles.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="aldryn aldryn-newsblog aldryn-newsblog-entries">
+<div class="aldryn aldryn-newsblog aldryn-newsblog-articles">
     {% for article in instance.get_articles %}
         {% include "aldryn_newsblog/includes/article.html" %}
     {% empty %}

--- a/aldryn_newsblog/cms_plugins.py
+++ b/aldryn_newsblog/cms_plugins.py
@@ -8,23 +8,18 @@ from django.utils.translation import ugettext_lazy as _
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 
-from . import forms, models
+from . import models
 
 
 class NewsBlogPlugin(CMSPluginBase):
     module = 'NewsBlog'
 
 
-# TODO: rename plugins to have a full app prefix
-#       (e.g NewsBlogLatestEntriesPlugin)
-#       https://github.com/divio/django-cms/issues/2562
-
-
-class BlogArchivePlugin(NewsBlogPlugin):
+class NewsBlogArchivePlugin(NewsBlogPlugin):
     render_template = 'aldryn_newsblog/plugins/archive.html'
     name = _('Archive')
     cache = False
-    model = models.ArchivePlugin
+    model = models.NewsBlogArchivePlugin
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance
@@ -32,27 +27,28 @@ class BlogArchivePlugin(NewsBlogPlugin):
             namespace=instance.app_config.namespace)
         return context
 
-plugin_pool.register_plugin(BlogArchivePlugin)
+plugin_pool.register_plugin(NewsBlogArchivePlugin)
 
 
-class LatestEntriesPlugin(NewsBlogPlugin):
-    render_template = 'aldryn_newsblog/plugins/latest_entries.html'
-    name = _('Latest Entries')
-    cache = False
-    model = models.LatestEntriesPlugin
+class NewsBlogAuthorsPlugin(NewsBlogPlugin):
+    render_template = 'aldryn_newsblog/plugins/authors.html'
+    name = _('Authors')
+    model = models.NewsBlogAuthorsPlugin
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance
+        context['article_list_url'] = reverse(
+            '{0}:article-list'.format(instance.app_config.namespace))
         return context
 
 
-plugin_pool.register_plugin(LatestEntriesPlugin)
+plugin_pool.register_plugin(NewsBlogAuthorsPlugin)
 
 
-class BlogCategoriesPlugin(NewsBlogPlugin):
+class NewsBlogCategoriesPlugin(NewsBlogPlugin):
     render_template = 'aldryn_newsblog/plugins/categories.html'
     name = _('Categories')
-    model = models.CategoriesPlugin
+    model = models.NewsBlogCategoriesPlugin
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance
@@ -62,45 +58,43 @@ class BlogCategoriesPlugin(NewsBlogPlugin):
         return context
 
 
-plugin_pool.register_plugin(BlogCategoriesPlugin)
+plugin_pool.register_plugin(NewsBlogCategoriesPlugin)
 
 
-class BlogTagsPlugin(NewsBlogPlugin):
-    render_template = 'aldryn_newsblog/plugins/tags.html'
-    name = _('Tags')
-    model = models.TagsPlugin
-
-    def render(self, context, instance, placeholder):
-        context['instance'] = instance
-        context['tags'] = instance.get_tags()
-        context['article_list_url'] = reverse(
-            '{0}:article-list'.format(instance.app_config.namespace))
-        return context
-
-
-plugin_pool.register_plugin(BlogTagsPlugin)
-
-
-class AuthorsPlugin(NewsBlogPlugin):
-    render_template = 'aldryn_newsblog/plugins/authors.html'
-    name = _('Blog Authors')
-    model = models.AuthorsPlugin
+class NewsBlogFeaturedArticlesPlugin(NewsBlogPlugin):
+    render_template = 'aldryn_newsblog/plugins/featured_articles.html'
+    name = _('Featured Articles')
+    cache = False
+    model = models.NewsBlogFeaturedArticlesPlugin
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance
-        context['article_list_url'] = reverse(
-            '{0}:article-list'.format(instance.app_config.namespace))
+        # article = self.get_article(context)
         return context
 
 
-plugin_pool.register_plugin(AuthorsPlugin)
+plugin_pool.register_plugin(NewsBlogFeaturedArticlesPlugin)
 
 
-class RelatedPlugin(NewsBlogPlugin):
+class NewsBlogLatestArticlesPlugin(NewsBlogPlugin):
+    render_template = 'aldryn_newsblog/plugins/latest_articles.html'
+    name = _('Latest Articles')
+    cache = False
+    model = models.NewsBlogLatestArticlesPlugin
+
+    def render(self, context, instance, placeholder):
+        context['instance'] = instance
+        return context
+
+
+plugin_pool.register_plugin(NewsBlogLatestArticlesPlugin)
+
+
+class NewsBlogRelatedPlugin(NewsBlogPlugin):
     render_template = 'aldryn_newsblog/plugins/related_articles.html'
     name = _('Related Articles')
     cache = False
-    model = models.RelatedPlugin
+    model = models.NewsBlogRelatedPlugin
 
     def get_article(self, context):
         request = context.get('request', None)
@@ -123,19 +117,20 @@ class RelatedPlugin(NewsBlogPlugin):
         return context
 
 
-plugin_pool.register_plugin(RelatedPlugin)
+plugin_pool.register_plugin(NewsBlogRelatedPlugin)
 
 
-class NewsBlogFeaturedArticlesPlugin(NewsBlogPlugin):
-    render_template = 'aldryn_newsblog/plugins/featured_articles.html'
-    name = _('Featured Articles')
-    cache = False
-    model = models.FeaturedArticlesPlugin
+class NewsBlogTagsPlugin(NewsBlogPlugin):
+    render_template = 'aldryn_newsblog/plugins/tags.html'
+    name = _('Tags')
+    model = models.NewsBlogTagsPlugin
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance
-        # article = self.get_article(context)
+        context['tags'] = instance.get_tags()
+        context['article_list_url'] = reverse(
+            '{0}:article-list'.format(instance.app_config.namespace))
         return context
 
 
-plugin_pool.register_plugin(NewsBlogFeaturedArticlesPlugin)
+plugin_pool.register_plugin(NewsBlogTagsPlugin)

--- a/aldryn_newsblog/cms_plugins.py
+++ b/aldryn_newsblog/cms_plugins.py
@@ -40,7 +40,6 @@ class LatestEntriesPlugin(NewsBlogPlugin):
     name = _('Latest Entries')
     cache = False
     model = models.LatestEntriesPlugin
-    form = forms.LatestEntriesForm
 
     def render(self, context, instance, placeholder):
         context['instance'] = instance

--- a/aldryn_newsblog/forms.py
+++ b/aldryn_newsblog/forms.py
@@ -1,5 +1,0 @@
-from django import forms
-
-
-class LatestEntriesForm(forms.ModelForm):
-    pass

--- a/aldryn_newsblog/managers.py
+++ b/aldryn_newsblog/managers.py
@@ -31,15 +31,15 @@ class RelatedManager(TranslatableManager):
         This means how many articles there are in each month.
 
         Returns list of dictionaries of the following format:
-        [{'date': date(YEAR, MONTH, ARBITRARY_DAY), 'num_entries': NUM_ENTRIES}, ...]
+        [{'date': date(YEAR, MONTH, ARBITRARY_DAY), 'num_articles': NUM_ARTICLES}, ...]
         ordered by date.
         """
 
         # TODO: check if this limitation still exists in Django 1.6+
         # This is done in a naive way as Django is having tough time while
         # aggregating on date fields
-        entries = self.filter(app_config__namespace=namespace)
-        dates = entries.values_list('publishing_date', flat=True)
+        articles = self.filter(app_config__namespace=namespace)
+        dates = articles.values_list('publishing_date', flat=True)
         dates = [(x.year, x.month) for x in dates]
         date_counter = Counter(dates)
         dates = set(dates)
@@ -48,7 +48,7 @@ class RelatedManager(TranslatableManager):
             # Use day=3 to make sure timezone won't affect this hacks'
             # month value. There are UTC+14 and UTC-12 timezones.
             {'date': datetime.date(year=year, month=month, day=3),
-             'num_entries': date_counter[(year, month)]}
+             'num_articles': date_counter[(year, month)]}
             for year, month in dates]
         return months
 
@@ -56,26 +56,26 @@ class RelatedManager(TranslatableManager):
         """
         Get authors with articles count for given namespace string.
 
-        Returns Person queryset annotated with and ordered by 'num_entries'.
+        Returns Person queryset annotated with and ordered by 'num_articles'.
         """
 
         # This methods relies on the fact that Article.app_config.namespace
         # is effectively unique for Article models
         return Person.objects.filter(
             article__app_config__namespace=namespace).annotate(
-            num_entries=models.Count('article')).order_by('-num_entries')
+            num_articles=models.Count('article')).order_by('-num_articles')
 
     def get_tags(self, namespace):
         """
         Get tags with articles count for given namespace string.
 
-        Returns list of Tag objects with ordered by custom 'num_entries' attribute.
+        Returns list of Tag objects with ordered by custom 'num_articles' attribute.
         """
 
-        entries = self.filter(app_config__namespace=namespace)
-        if not entries:
+        articles = self.filter(app_config__namespace=namespace)
+        if not articles:
             return []
-        kwargs = TaggedItem.bulk_lookup_kwargs(entries)
+        kwargs = TaggedItem.bulk_lookup_kwargs(articles)
 
         # aggregate and sort
         counted_tags = dict(TaggedItem.objects
@@ -87,5 +87,5 @@ class RelatedManager(TranslatableManager):
         # and finally get the results
         tags = Tag.objects.filter(pk__in=counted_tags.keys())
         for tag in tags:
-            tag.num_entries = counted_tags[tag.pk]
-        return sorted(tags, key=attrgetter('num_entries'), reverse=True)
+            tag.num_articles = counted_tags[tag.pk]
+        return sorted(tags, key=attrgetter('num_articles'), reverse=True)

--- a/aldryn_newsblog/south_migrations/0027_rename_plugins_to_include_appname.py
+++ b/aldryn_newsblog/south_migrations/0027_rename_plugins_to_include_appname.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Renaming model 'TagsPlugin'
+        db.rename_table(u'aldryn_newsblog_tagsplugin', u'aldryn_newsblog_newsblogtagsplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='tagsplugin').update(model='newsblogtagsplugin')
+
+        # Renaming model 'AuthorsPlugin'
+        db.rename_table(u'aldryn_newsblog_authorsplugin', u'aldryn_newsblog_newsblogauthorsplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='authorsplugin').update(model='newsblogauthorsplugin')
+
+        # Renaming model 'CategoriesPlugin'
+        db.rename_table(u'aldryn_newsblog_categoriesplugin', u'aldryn_newsblog_newsblogcategoriesplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='categoriesplugin').update(model='newsblogcategoriesplugin')
+
+        # Renaming model 'FeaturedArticlesPlugin'
+        db.rename_table(u'aldryn_newsblog_featuredarticlesplugin', u'aldryn_newsblog_newsblogfeaturedarticlesplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='featuredarticlesplugin').update(model='newsblogfeaturedarticlesplugin')
+
+        # Renaming model 'LatestEntriesPlugin'
+        db.rename_table(u'aldryn_newsblog_latestentriesplugin', u'aldryn_newsblog_newsbloglatestarticlesplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='latestentriesplugin').update(model='newsbloglatestarticlesplugin')
+        # Also, rename latest_entries -> latest_articles
+        db.rename_column('aldryn_newsblog_newsbloglatestarticlesplugin', 'latest_entries', 'latest_articles')
+
+        # Renaming model 'RelatedPlugin'
+        db.rename_table(u'aldryn_newsblog_relatedplugin', u'aldryn_newsblog_newsblogrelatedplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='relatedplugin').update(model='newsblogrelatedplugin')
+
+        # Renaming model 'ArchivePlugin'
+        db.rename_table(u'aldryn_newsblog_archiveplugin', u'aldryn_newsblog_newsblogarchiveplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='archiveplugin').update(model='newsblogarchiveplugin')
+
+    def backwards(self, orm):
+
+        # Renaming model 'TagsPlugin'
+        db.rename_table(u'aldryn_newsblog_newsblogtagsplugin', u'aldryn_newsblog_tagsplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsblogtagsplugin').update(model='tagsplugin')
+
+        # Renaming model 'AuthorsPlugin'
+        db.rename_table(u'aldryn_newsblog_newsblogauthorsplugin', u'aldryn_newsblog_authorsplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsblogauthorsplugin').update(model='authorsplugin')
+
+        # Renaming model 'CategoriesPlugin'
+        db.rename_table(u'aldryn_newsblog_newsblogcategoriesplugin', u'aldryn_newsblog_categoriesplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsblogcategoriesplugin').update(model='categoriesplugin')
+
+        # Renaming model 'FeaturedArticlesPlugin'
+        db.rename_table(u'aldryn_newsblog_newsblogfeaturedarticlesplugin', u'aldryn_newsblog_featuredarticlesplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsblogfeaturedarticlesplugin').update(model='featuredarticlesplugin')
+
+        # Rename latest_articles -> latest_entries
+        db.rename_column('aldryn_newsblog_newsbloglatestarticlesplugin', 'latest_articles', 'latest_entries')
+        # Renaming model 'LatestEntriesPlugin'
+        db.rename_table(u'aldryn_newsblog_newsbloglatestarticlesplugin', u'aldryn_newsblog_latestentriesplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsbloglatestarticlesplugin').update(model='latestentriesplugin')
+
+        # Renaming model 'RelatedPlugin'
+        db.rename_table(u'aldryn_newsblog_newsblogrelatedplugin', u'aldryn_newsblog_relatedplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsblogrelatedplugin').update(model='relatedplugin')
+
+        # Renaming model 'ArchivePlugin'
+        db.rename_table(u'aldryn_newsblog_newsblogarchiveplugin', u'aldryn_newsblog_archiveplugin')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(
+                app_label='aldryn_newsblog', model='newsblogarchiveplugin').update(model='archiveplugin')
+
+    models = {
+        u'aldryn_categories.category': {
+            'Meta': {'object_name': 'Category'},
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'rgt': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'aldryn_newsblog.article': {
+            'Meta': {'ordering': "[u'-publishing_date']", 'object_name': 'Article'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'categories': ('aldryn_categories.fields.CategoryManyToManyField', [], {'to': u"orm['aldryn_categories.Category']", 'symmetrical': 'False', 'blank': 'True'}),
+            'content': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_articles'", 'unique': 'True', 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'featured_image': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['filer.Image']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'publishing_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'related': ('sortedm2m.fields.SortedManyToManyField', [], {'related_name': "'related_rel_+'", 'blank': 'True', 'to': u"orm['aldryn_newsblog.Article']"})
+        },
+        u'aldryn_newsblog.articletranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'slug'), (u'language_code', u'master')]", 'object_name': 'ArticleTranslation', 'db_table': "u'aldryn_newsblog_article_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'lead_in': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.Article']"}),
+            'meta_description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_keywords': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '234'})
+        },
+        u'aldryn_newsblog.newsblogarchiveplugin': {
+            'Meta': {'object_name': 'NewsBlogArchivePlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogauthorsplugin': {
+            'Meta': {'object_name': 'NewsBlogAuthorsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogcategoriesplugin': {
+            'Meta': {'object_name': 'NewsBlogCategoriesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogconfig': {
+            'Meta': {'object_name': 'NewsBlogConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            'create_authors': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'detail_view_placeholder': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_view_placeholder_set'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'list_view_placeholder': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_list_view_placeholder_set'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '100'}),
+            'paginate_by': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'search_indexed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_newsblog.newsblogconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'NewsBlogConfigTranslation', 'db_table': "u'aldryn_newsblog_newsblogconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'max_length': '234'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.NewsBlogConfig']"})
+        },
+        u'aldryn_newsblog.newsblogfeaturedarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogFeaturedArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'article_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsbloglatestarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogLatestArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"}),
+            'latest_articles': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        u'aldryn_newsblog.newsblogrelatedplugin': {
+            'Meta': {'object_name': 'NewsBlogRelatedPlugin', '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogtagsplugin': {
+            'Meta': {'object_name': 'NewsBlogTagsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_newsblog']

--- a/aldryn_newsblog/south_migrations/0028_convert_plugins.py
+++ b/aldryn_newsblog/south_migrations/0028_convert_plugins.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+
+class Migration(DataMigration):
+
+    mapping = (
+        ('BlogTagsPlugin', 'NewsBlogTagsPlugin', ),
+        ('AuthorsPlugin', 'NewsBlogAuthorsPlugin', ),
+        ('BlogCategoriesPlugin', 'NewsBlogCategoriesPlugin', ),
+        ('LatestEntriesPlugin', 'NewsBlogLatestArticlesPlugin', ),
+        ('RelatedPlugin', 'NewsBlogRelatedPlugin', ),
+        ('BlogArchivePlugin', 'NewsBlogArchivePlugin', ),
+    )
+
+    def forwards(self, orm):
+        for plugin in orm['cms.CMSPlugin'].objects.all():
+            for m in self.mapping:
+                if plugin.plugin_type == m[0]:
+                    plugin.plugin_type = m[1]
+                    plugin.save()
+                    break
+
+    def backwards(self, orm):
+        for plugin in orm['cms.CMSPlugin'].objects.all():
+            for m in self.mapping:
+                if plugin.plugin_type == m[1]:
+                    plugin.plugin_type = m[0]
+                    plugin.save()
+                    break
+
+    models = {
+        u'aldryn_categories.category': {
+            'Meta': {'object_name': 'Category'},
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'rgt': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'aldryn_newsblog.article': {
+            'Meta': {'ordering': "[u'-publishing_date']", 'object_name': 'Article'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'categories': ('aldryn_categories.fields.CategoryManyToManyField', [], {'to': u"orm['aldryn_categories.Category']", 'symmetrical': 'False', 'blank': 'True'}),
+            'content': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_articles'", 'unique': 'True', 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'featured_image': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['filer.Image']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'publishing_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'related': ('sortedm2m.fields.SortedManyToManyField', [], {'related_name': "'related_rel_+'", 'blank': 'True', 'to': u"orm['aldryn_newsblog.Article']"})
+        },
+        u'aldryn_newsblog.articletranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'slug'), (u'language_code', u'master')]", 'object_name': 'ArticleTranslation', 'db_table': "u'aldryn_newsblog_article_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'lead_in': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.Article']"}),
+            'meta_description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_keywords': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '234'})
+        },
+        u'aldryn_newsblog.newsblogarchiveplugin': {
+            'Meta': {'object_name': 'NewsBlogArchivePlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogauthorsplugin': {
+            'Meta': {'object_name': 'NewsBlogAuthorsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogcategoriesplugin': {
+            'Meta': {'object_name': 'NewsBlogCategoriesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogconfig': {
+            'Meta': {'object_name': 'NewsBlogConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            'create_authors': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'detail_view_placeholder': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_view_placeholder_set'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'list_view_placeholder': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_list_view_placeholder_set'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '100'}),
+            'paginate_by': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'search_indexed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_newsblog.newsblogconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'NewsBlogConfigTranslation', 'db_table': "u'aldryn_newsblog_newsblogconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'max_length': '234'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.NewsBlogConfig']"})
+        },
+        u'aldryn_newsblog.newsblogfeaturedarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogFeaturedArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'article_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsbloglatestarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogLatestArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"}),
+            'latest_articles': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        u'aldryn_newsblog.newsblogrelatedplugin': {
+            'Meta': {'object_name': 'NewsBlogRelatedPlugin', '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogtagsplugin': {
+            'Meta': {'object_name': 'NewsBlogTagsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_newsblog']
+    symmetrical = True

--- a/aldryn_newsblog/tests/test_aldryn_newsblog.py
+++ b/aldryn_newsblog/tests/test_aldryn_newsblog.py
@@ -389,26 +389,26 @@ class TestAldrynNewsBlog(NewsBlogTestsMixin, TransactionTestCase):
 
     def test_articles_count_by_month(self):
         months = [
-            {'date': date(1914, 7, 3), 'num_entries': 1},
-            {'date': date(1914, 8, 3), 'num_entries': 3},
-            {'date': date(1945, 9, 3), 'num_entries': 5},
+            {'date': date(1914, 7, 3), 'num_articles': 1},
+            {'date': date(1914, 8, 3), 'num_articles': 3},
+            {'date': date(1945, 9, 3), 'num_articles': 5},
         ]
         for month in months:
-            for _ in range(month['num_entries']):
+            for _ in range(month['num_articles']):
                 self.create_article(publishing_date=month['date'])
         self.assertEquals(
             sorted(
                 Article.objects.get_months(
                     namespace=self.app_config.namespace),
-                key=itemgetter('num_entries')),
+                key=itemgetter('num_articles')),
             months)
 
     def test_articles_count_by_author(self):
         authors = []
-        for num_entries in [1, 3, 5]:
+        for num_articles in [1, 3, 5]:
             person = self.create_person()
-            person.num_entries = num_entries
-            authors.append((person, num_entries))
+            person.num_articles = num_articles
+            authors.append((person, num_articles))
 
         for i, data in enumerate(authors):
             for _ in range(data[1]):
@@ -420,7 +420,7 @@ class TestAldrynNewsBlog(NewsBlogTestsMixin, TransactionTestCase):
             sorted(
                 Article.objects.get_authors(
                     namespace=self.app_config.namespace).values_list(
-                        'pk', 'num_entries'),
+                        'pk', 'num_articles'),
                 key=itemgetter(1)),
             authors)
 
@@ -444,7 +444,7 @@ class TestAldrynNewsBlog(NewsBlogTestsMixin, TransactionTestCase):
             (tag_slug1, 1),
         ]
         tags = Article.objects.get_tags(namespace=self.app_config.namespace)
-        tags = map(lambda x: (x.slug, x.num_entries), tags)
+        tags = map(lambda x: (x.slug, x.num_articles), tags)
         self.assertEquals(tags, tags_expected)
 
     def test_articles_by_date(self):
@@ -584,13 +584,14 @@ class TestAldrynNewsBlog(NewsBlogTestsMixin, TransactionTestCase):
         self.assertEquals(article.author.name,
                           u' '.join((user.first_name, user.last_name)))
 
-    def test_latest_entries_plugin(self):
+    def test_latest_articles_plugin(self):
         page = api.create_page(
             'plugin page', self.template, self.language,
             parent=self.root_page, published=True)
         placeholder = page.placeholders.all()[0]
-        api.add_plugin(placeholder, 'LatestEntriesPlugin', self.language,
-                       app_config=self.app_config, latest_entries=7)
+        api.add_plugin(placeholder, 'NewsBlogLatestArticlesPlugin',
+                       self.language, app_config=self.app_config,
+                       latest_articles=7)
         plugin = placeholder.get_plugins()[0].get_plugin_instance()[0]
         plugin.save()
         page.publish(self.language)

--- a/aldryn_newsblog/tests/test_aldryn_newsblog.py
+++ b/aldryn_newsblog/tests/test_aldryn_newsblog.py
@@ -354,7 +354,7 @@ class TestAldrynNewsBlog(NewsBlogTestsMixin, TransactionTestCase):
         article = self.create_article(author=author, featured_image=image)
         response = self.client.get(article.get_absolute_url())
         image_url = get_thumbnailer(article.featured_image).get_thumbnail({
-            'size': (800, 300),
+            'size': (800, 450),
             'crop': True,
             'subject_location': article.featured_image.subject_location
         }).url


### PR DESCRIPTION
This PR should fix #90, #122, #123 and #126.

All plugins and their models now use app-prefixed names, so, NewsBlogArchivePlugin rather than just ArchivePlugin. Also the the word 'article' now replaces 'entry' throughout. All plugins now use "+" for the related_name to avoid conflicts with other apps in projects. Finally, the empty form declaration has been removed.

There's a lot going on here (all related though), so please do review (and preferably test on a real project after backing up your DB!)

attn: @czpython @mikek @FinalAngel 