### PR TITLE
Stub-out the migration

### DIFF
--- a/aldryn_newsblog/south_migrations/0014_create_default_namespace.py
+++ b/aldryn_newsblog/south_migrations/0014_create_default_namespace.py
@@ -9,16 +9,10 @@ from django.db.transaction import set_autocommit
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        if connection.vendor == 'sqlite':
-            set_autocommit(True)
-
-        ns, created = orm.NewsBlogConfig.objects.get_or_create(
-            namespace='latest_entries_plugin_default_namespace')
-
-        for plugin in orm.LatestEntriesPlugin.objects.all():
-            if plugin.namespace is None:
-                plugin.namespace = ns
-                plugin.save()
+        """
+        This was used to make a default namespace, but now its just a
+        null migration.
+        """
 
     def backwards(self, orm):
         "Write your backwards methods here."


### PR DESCRIPTION
This simply removes the addition of the default namespace in the special migration. I was able to create a new project and everything works as expected. Tests run.