### PR TITLE
Re-add global kill-switch for search indexing for Haystack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,16 @@ __ http://django-filer.readthedocs.org/en/latest/installation.html#subject-locat
 5) (Re-)Start your application server.
 
 
+Settings
+~~~~~~~~
+
+The flag `ALDRYN_NEWSBLOG_SEARCH` can be set to `False` in settings if indexing
+should be globally disabled for NewsBlog. When this is `False`, it overrides
+the setting in the application configuration on each apphook.
+
+If aldryn-search, Haystack, et al, are not installed, this setting does nothing.
+
+
 -----
 Notes
 -----

--- a/aldryn_newsblog/search_indexes.py
+++ b/aldryn_newsblog/search_indexes.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
+
 from aldryn_search.utils import get_index_base
 
 from .models import Article
 
 
 class ArticleIndex(get_index_base()):
-    haystack_use_for_indexing = True
+    haystack_use_for_indexing = getattr(
+        settings, 'ALDRYN_NEWSBLOG_SEARCH', True)
 
     index_title = True
 


### PR DESCRIPTION
Leaves the per-app-hook setting intact though.