### PR TITLE
Remove deprecated static placeholders

### DIFF
--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/article_detail.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/article_detail.html
@@ -6,8 +6,6 @@
     <div class="aldryn-newsblog-detail">
         {% include "aldryn_newsblog/includes/article.html" with detail_view="true" %}
     </div>
-    {# DEPRECATED - STATIC PLACEHOLDER "NEWSBLOG_DETAIL_VIEW" WILL BE REMOVED IN 0.6.0 #}
-    {% static_placeholder "newsblog_detail_view" %}
     {% render_placeholder view.config.placeholder_detail_bottom %}
 {% endblock %}
 
@@ -27,7 +25,5 @@
             {% endif %}
         </ul>
     </div>
-    {# DEPRECATED - STATIC PLACEHOLDER "NEWSBLOG_DETAIL_FOOTER" WILL BE REMOVED IN 0.6.0 #}
-    {% static_placeholder "newsblog_detail_footer" %}
     {% render_placeholder view.config.placeholder_detail_footer %}
 {% endblock %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/fullwidth.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/fullwidth.html
@@ -6,8 +6,6 @@
     <div class="row">
         <div class="col-md-16 col-md-push-4">
             {% if view.show_header %}
-            {# DEPRECATED - STATIC PLACEHOLDER "NEWSBLOG_TOP" WILL BE REMOVED IN 0.6.0 #}
-            {% static_placeholder "newsblog_top" %}
             {% render_placeholder view.config.placeholder_base_top %}
             {% endif %}
             <div class="aldryn aldryn-newsblog">

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/two_column.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/two_column.html
@@ -6,8 +6,6 @@
     <div class="row">
         <div class="col-md-17">
             {% if view.show_header %}
-            {# DEPRECATED - STATIC PLACEHOLDER "NEWSBLOG_TOP" WILL BE REMOVED IN 0.6.0 #}
-            {% static_placeholder "newsblog_top" %}
             {% render_placeholder view.config.placeholder_base_top %}
             {% endif %}
             <div class="aldryn aldryn-newsblog">
@@ -17,8 +15,6 @@
             </div>
         </div>
         <div class="col-md-7 aldryn-newsblog aldryn-newsblog-sidebar">
-            {# DEPRECATED - STATIC PLACEHOLDER "NEWSBLOG_SIDEBAR" WILL BE REMOVED IN 0.6.0 #}
-            {% static_placeholder "newsblog_sidebar" %}
             {% render_placeholder view.config.placeholder_base_sidebar %}
             {% block newsblog_sidebar %}{% endblock %}
         </div>


### PR DESCRIPTION
These static placeholders were deprecated in 0.5.0.