### PR TITLE
Display details by default

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -82,7 +82,6 @@ class ArticleAdmin(VersionedPlaceholderAdminMixin,
             )
         }),
         ('Details', {
-            'classes': ('collapse',),
             'fields': (
                 'is_featured',
                 'tags',


### PR DESCRIPTION
CKEditor it `lead_in` HTMLField is rendered only if textarea is visible (https://github.com/divio/djangocms-text-ckeditor/blob/master/djangocms_text_ckeditor/templates/cms/plugins/widgets/ckeditor.html#L20)
Collapsed fields are hidden so CKEditor isn't added.