### PR TITLE
Fixes preview mode for the categories and authors plugins

### DIFF
--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/includes/author.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/includes/author.html
@@ -16,7 +16,7 @@
         <p class="author"><a href="{% namespace_url "article-list-by-author" author.slug namespace=namespace %}">{{ author.name }}</a></p>
         {% if author_view and author.slug %}
             <p class="job">{{ author.function }}</p>
-            <p class="badge">{{ author.count }}</p>
+            <p class="badge">{{ author.article_count }}</p>
         {% else %}
             <p class="date">{{ article.publishing_date|date }}</p>
         {% endif %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/categories.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/categories.html
@@ -7,7 +7,7 @@
         </li>
         {% for category in categories %}
             <li{% if newsblog_category.id == category.id %} class="active"{% endif %}>
-                <span class="badge">{{ category.count }}</span>
+                <span class="badge">{{ category.article_count }}</span>
                 <a href="{% namespace_url "article-list-by-category" category.slug namespace=instance.app_config.namespace %}">{{ category.name }}</a>
             </li>
         {% endfor %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/tags.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/plugins/tags.html
@@ -9,7 +9,7 @@
             <li{% if newsblog_tag.id == tag.id %} class="active"{% endif %}>
                 <a href="{% namespace_url "article-list-by-tag" tag.slug namespace=instance.app_config.namespace %}">
                     {{ tag.name }}
-                    <span class="badge">{{ tag.count }}</span>
+                    <span class="badge">{{ tag.article_count }}</span>
                 </a>
             </li>
         {% endfor %}

--- a/aldryn_newsblog/cms_plugins.py
+++ b/aldryn_newsblog/cms_plugins.py
@@ -120,8 +120,7 @@ class NewsBlogRelatedPlugin(NewsBlogPlugin):
     cache = False
     model = models.NewsBlogRelatedPlugin
 
-    def get_article(self, context):
-        request = context.get('request')
+    def get_article(self, request):
         if request and request.resolver_match:
             view_name = request.resolver_match.view_name
             namespace = request.resolver_match.namespace
@@ -133,11 +132,12 @@ class NewsBlogRelatedPlugin(NewsBlogPlugin):
         return None
 
     def render(self, context, instance, placeholder):
+        request = context.get('request')
         context['instance'] = instance
-        article = self.get_article(context)
+        article = self.get_article(request)
         if article:
             context['article'] = article
-            context['article_list'] = article.related.all()
+            context['article_list'] = instance.get_articles(article, request)
         return context
 
 

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -126,7 +126,8 @@ class Article(TranslatableModel):
                 '{namespace}:article-detail'.format(
                     namespace=self.app_config.namespace
                 ), kwargs={
-                    'slug': self.safe_translation_getter('slug', any_language=True)
+                    'slug': self.safe_translation_getter(
+                        'slug', any_language=True)
                 }
             )
         except:

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -274,12 +274,15 @@ class NewsBlogAuthorsPlugin(PluginEditModeMixin, NewsBlogCMSPlugin):
         edit_mode = self.edit_mode(request)
         authors = Person.objects
         author_list = []
+
         for author in authors.all():
-            if edit_mode:
-                count = Article.objects.filter(author=author).count()
-            else:
-                count = Article.objects.published().filter(author=author).count()
-            author.count = count
+            count_qs = Article.objects
+            if not edit_mode:
+                count_qs = count_qs.published()
+            author.count = count_qs.filter(
+                author=author,
+                app_config=self.app_config,
+            ).count()
             author_list.append(author)
         return author_list
 

--- a/aldryn_newsblog/tests/__init__.py
+++ b/aldryn_newsblog/tests/__init__.py
@@ -65,7 +65,6 @@ class NewsBlogTestsMixin(CategoryTestCaseMixin):
         if content:
             api.add_plugin(article.content, 'TextPlugin',
                            self.language, body=content)
-
         return article
 
     def create_tagged_articles(self, num_articles=3, tags=('tag1', 'tag2'),

--- a/aldryn_newsblog/tests/test_plugins.py
+++ b/aldryn_newsblog/tests/test_plugins.py
@@ -109,6 +109,7 @@ class TestAuthorsPlugin(TestAppConfigPluginsBase):
             app_config=self.another_app_config
         ))
 
+        # REQUIRED DUE TO USE OF RAW QUERIES
         time.sleep(1)
 
         response = self.client.get(self.page.get_absolute_url())
@@ -162,6 +163,7 @@ class TestCategoriesPlugin(TestAppConfigPluginsBase):
             article.categories.add(self.category1)
             other_articles.append(article)
 
+        # REQUIRED DUE TO USE OF RAW QUERIES
         time.sleep(1)
 
         response = self.client.get(self.page.get_absolute_url())
@@ -261,7 +263,10 @@ class TestTagsPlugin(TestAppConfigPluginsBase):
         # Some tag1 articles in another namespace
         other_articles += self.create_tagged_articles(
             1, tags=['tag1'], app_config=self.another_app_config)['tag1']
+
+        # REQUIRED DUE TO USE OF RAW QUERIES
         time.sleep(1)
+
         response = self.client.get(self.page.get_absolute_url())
         self.assertRegexpMatches(str(response), 'tag1\s*<span[^>]*>3</span>')
         self.assertRegexpMatches(str(response), 'tag2\s*<span[^>]*>5</span>')

--- a/aldryn_newsblog/tests/test_plugins.py
+++ b/aldryn_newsblog/tests/test_plugins.py
@@ -6,7 +6,7 @@ import datetime
 import pytz
 
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TransactionTestCase
 
 from aldryn_newsblog.models import NewsBlogConfig
 from cms import api
@@ -14,7 +14,7 @@ from cms import api
 from . import NewsBlogTestsMixin
 
 
-class TestAppConfigPluginsBase(NewsBlogTestsMixin, TestCase):
+class TestAppConfigPluginsBase(NewsBlogTestsMixin, TransactionTestCase):
     plugin_to_test = 'TextPlugin'
     plugin_params = {}
 
@@ -216,7 +216,7 @@ class TestLatestArticlesPlugin(TestAppConfigPluginsBase):
             self.assertNotContains(response, article.title)
 
 
-class TestRelatedArticlesPlugin(NewsBlogTestsMixin, TestCase):
+class TestRelatedArticlesPlugin(NewsBlogTestsMixin, TransactionTestCase):
 
     def test_related_articles_plugin(self):
         main_article = self.create_article(app_config=self.app_config)

--- a/aldryn_newsblog/tests/test_plugins.py
+++ b/aldryn_newsblog/tests/test_plugins.py
@@ -101,7 +101,7 @@ class TestAuthorsPlugin(TestAppConfigPluginsBase):
                 is_published=False
             )
             other_articles.append(article)
-        
+
         # Published, author1 articles in a different namespace
         other_articles.append(self.create_article(
             author=author1,

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -133,7 +133,7 @@ class TestViews(NewsBlogTestsMixin, TransactionTestCase):
                     with switch_language(category, language):
                         url = reverse('aldryn_newsblog:article-list-by-category',
                                       kwargs={'category': category.slug})
-                    response = self.client.get(url)
+                        response = self.client.get(url)
                     for article in articles:
                         if language in article.get_available_languages():
                             article.set_current_language(language)

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -160,7 +160,8 @@ class TestTranslationFallbacks(NewsBlogTestsMixin, TransactionTestCase):
 
         with override(settings.LANGUAGES[0][0]):
             article = Article.objects.create(
-                title=self.rand_str(), slug=self.rand_str(prefix=code),
+                title=self.rand_str(),
+                slug=self.rand_str(prefix=code),
                 app_config=self.app_config,
                 author=author, owner=author.user,
                 publishing_date=now())

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -11,7 +11,7 @@ from random import randint
 from django.conf import settings
 from django.core.files import File as DjangoFile
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TransactionTestCase
 from django.utils.timezone import now
 from django.utils.translation import get_language, override
 
@@ -50,7 +50,7 @@ PARLER_LANGUAGES_SHOW = {
 }
 
 
-class TestViews(NewsBlogTestsMixin, TestCase):
+class TestViews(NewsBlogTestsMixin, TransactionTestCase):
 
     def test_articles_list(self):
         articles = [self.create_article() for _ in range(11)]
@@ -149,7 +149,7 @@ class TestViews(NewsBlogTestsMixin, TestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class TestTranslationFallbacks(NewsBlogTestsMixin, TestCase):
+class TestTranslationFallbacks(NewsBlogTestsMixin, TransactionTestCase):
     def test_article_detail_not_translated_fallback(self):
         """
         If the fallback is configured, article is available in any
@@ -231,7 +231,7 @@ class TestTranslationFallbacks(NewsBlogTestsMixin, TestCase):
                 self.assertEqual(response.status_code, 404)
 
 
-class TestImages(NewsBlogTestsMixin, TestCase):
+class TestImages(NewsBlogTestsMixin, TransactionTestCase):
     def test_article_detail_show_featured_image(self):
         author = self.create_person()
         with open(FEATURED_IMAGE_PATH, 'rb') as f:
@@ -250,7 +250,7 @@ class TestImages(NewsBlogTestsMixin, TestCase):
         self.assertContains(response, image_url)
 
 
-class TestVariousViews(NewsBlogTestsMixin, TestCase):
+class TestVariousViews(NewsBlogTestsMixin, TransactionTestCase):
     def test_articles_by_tag(self):
         """
         Tests that TagArticleList view properly filters articles by their tags.
@@ -433,7 +433,7 @@ class TestVariousViews(NewsBlogTestsMixin, TestCase):
             self.assertNotContains(response, article.title)
 
 
-class TestIndex(NewsBlogTestsMixin, TestCase):
+class TestIndex(NewsBlogTestsMixin, TransactionTestCase):
     def test_index_simple(self):
         self.index = ArticleIndex()
         content0 = self.rand_str(prefix='content0_')

--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -111,6 +111,7 @@ class ArticleSearchResultsList(ArticleListBase):
     def get(self, request, *args, **kwargs):
         self.query = request.GET.get('q')
         self.max_articles = request.GET.get('max_articles', 0)
+        self.edit_mode = (request.toolbar and request.toolbar.edit_mode)
         return super(ArticleSearchResultsList, self).get(request)
 
     def get_paginate_by(self, queryset):
@@ -123,6 +124,8 @@ class ArticleSearchResultsList(ArticleListBase):
 
     def get_queryset(self):
         qs = super(ArticleSearchResultsList, self).get_queryset()
+        if not self.edit_mode:
+            qs = qs.published()
         if self.query:
             return qs.filter(
                 Q(translations__title__icontains=self.query) |

--- a/test_settings.py
+++ b/test_settings.py
@@ -84,22 +84,22 @@ HELPER_SETTINGS = {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': 'mydatabase',
         },
-        # 'mysql': {
-        #     'ENGINE': 'django.db.backends.mysql',
-        #     'NAME': 'djangocms_test',
-        #     'USER': 'root',
-        #     'PASSWORD': '',
-        #     'HOST': '',
-        #     'PORT': '3306',
-        # },
-        # 'default': {
-        #     'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        #     'NAME': 'newsblog_test',
-        #     'USER': 'test',
-        #     'PASSWORD': '',
-        #     'HOST': '127.0.0.1',
-        #     'PORT': '5432',
-        # }
+        'mysql': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'newsblog_test',
+            'USER': 'root',
+            'PASSWORD': '',
+            'HOST': '',
+            'PORT': '3306',
+        },
+        'postgres': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': 'newsblog_test',
+            'USER': 'test',
+            'PASSWORD': '',
+            'HOST': '127.0.0.1',
+            'PORT': '5432',
+        }
     }
 }
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -79,28 +79,28 @@ HELPER_SETTINGS = {
         'filer.thumbnail_processors.scale_and_crop_with_subject_location',
         'easy_thumbnails.processors.filters',
     ),
-    'DATABASES': {
-        'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': 'mydatabase',
-        },
-        'mysql': {
-            'ENGINE': 'django.db.backends.mysql',
-            'NAME': 'newsblog_test',
-            'USER': 'root',
-            'PASSWORD': '',
-            'HOST': '',
-            'PORT': '3306',
-        },
-        'postgres': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'newsblog_test',
-            'USER': 'test',
-            'PASSWORD': '',
-            'HOST': '127.0.0.1',
-            'PORT': '5432',
-        }
-    }
+    # 'DATABASES': {
+    #     'default': {
+    #         'ENGINE': 'django.db.backends.sqlite3',
+    #         'NAME': 'mydatabase',
+    #     },
+    #     'mysql': {
+    #         'ENGINE': 'django.db.backends.mysql',
+    #         'NAME': 'newsblog_test',
+    #         'USER': 'root',
+    #         'PASSWORD': '',
+    #         'HOST': '',
+    #         'PORT': '3306',
+    #     },
+    #     'postgres': {
+    #         'ENGINE': 'django.db.backends.postgresql_psycopg2',
+    #         'NAME': 'newsblog_test',
+    #         'USER': 'test',
+    #         'PASSWORD': '',
+    #         'HOST': '127.0.0.1',
+    #         'PORT': '5432',
+    #     }
+    # }
 }
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -75,10 +75,32 @@ HELPER_SETTINGS = {
     'THUMBNAIL_PROCESSORS': (
         'easy_thumbnails.processors.colorspace',
         'easy_thumbnails.processors.autocrop',
-        #'easy_thumbnails.processors.scale_and_crop',
+        # 'easy_thumbnails.processors.scale_and_crop',
         'filer.thumbnail_processors.scale_and_crop_with_subject_location',
         'easy_thumbnails.processors.filters',
-    )
+    ),
+    'DATABASES': {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': 'mydatabase',
+        },
+        # 'mysql': {
+        #     'ENGINE': 'django.db.backends.mysql',
+        #     'NAME': 'djangocms_test',
+        #     'USER': 'root',
+        #     'PASSWORD': '',
+        #     'HOST': '',
+        #     'PORT': '3306',
+        # },
+        # 'default': {
+        #     'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        #     'NAME': 'newsblog_test',
+        #     'USER': 'test',
+        #     'PASSWORD': '',
+        #     'HOST': '127.0.0.1',
+        #     'PORT': '5432',
+        # }
+    }
 }
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -48,6 +48,17 @@ HELPER_SETTINGS = {
             'hide_untranslated': False,
         }
     },
+    #
+    # NOTE: The following setting `PARLER_ENABLE_CACHING = False` is required
+    # for tests to pass.
+    #
+    # There appears to be a bug in Parler which leaves translations in Parler's
+    # cache even after the parent object has been deleted. In production
+    # environments, this is unlikely to affect anything, because newly created
+    # objects will have new IDs. In testing, new objects are created with IDs
+    # that were previously used, which reveals this issue.
+    #
+    'PARLER_ENABLE_CACHING': False,
     'HAYSTACK_CONNECTIONS': {
         'default': {
             'ENGINE': 'haystack.backends.simple_backend.SimpleEngine',


### PR DESCRIPTION
This PR adds more test-coverage (now > 90%) and wider support (full support?) for "Preview Mode". For example, the badges for each category/author/tag on the respective plugins will now reflect the number of articles visible to the user.

Also, to allow these plugins to be useful in production settings, they've been refactored to use 1 query rather than N+1. In order to do this, raw SQL queries need to be used. Support for SQLite, MySQL, PostgresSQL and Oracle have been added, SQLite, MySQL and PostgresSQL have been tested to work.