### PR TITLE
Configurable permalink types and handling

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -135,6 +135,8 @@ class NewsBlogConfigAdmin(TranslatableAdmin,
                           PlaceholderAdminMixin,
                           BaseAppHookConfig):
     def get_config_fields(self):
-        return ('app_title', 'paginate_by', 'create_authors', 'search_indexed', 'config.default_published', )
+        return (
+            'app_title', 'permalink_type', 'non_permalink_handling', 'paginate_by', 'create_authors',
+            'search_indexed', 'config.default_published', )
 
 admin.site.register(models.NewsBlogConfig, NewsBlogConfigAdmin)

--- a/aldryn_newsblog/cms_appconfig.py
+++ b/aldryn_newsblog/cms_appconfig.py
@@ -14,12 +14,36 @@ from cms.models.fields import PlaceholderField
 from parler.models import TranslatableModel
 from parler.models import TranslatedFields
 
+PERMALINK_CHOICES = (
+    ('s', _('the-eagle-has-landed/', )),
+    ('ys', _('1969/the-eagle-has-landed/', )),
+    ('yms', _('1969/07/the-eagle-has-landed/', )),
+    ('ymds', _('1969/07/16/the-eagle-has-landed/', )),
+    ('ymdi', _('1969/07/16/11/', )),
+)
+
+NON_PERMALINK_HANDLING = (
+    (200, _('Allow')),
+    (302, _('Redirect to permalink (default)')),
+    (301, _('Permanent redirect to permalink')),
+    (404, _('Return 404: Not Found')),
+)
+
 
 class NewsBlogConfig(TranslatableModel, AppHookConfig):
     """Adds some translatable, per-app-instance fields."""
     translations = TranslatedFields(
         app_title=models.CharField(_('application title'), max_length=234),
     )
+
+    permalink_type = models.CharField(_('permalink type'), max_length=8,
+        blank=False, default='slug', choices=PERMALINK_CHOICES,
+        help_text=_('Choose the style of urls to use from the examples. (Note, all types are relative to apphook)'))
+
+    non_permalink_handling = models.SmallIntegerField(_('non-permalink handling'),
+        blank=False, default=302,
+        choices=NON_PERMALINK_HANDLING,
+        help_text=_('How to handle non-permalink urls?'))
 
     # ALDRYN_NEWSBLOG_PAGINATE_BY
     paginate_by = models.PositiveIntegerField(

--- a/aldryn_newsblog/cms_toolbar.py
+++ b/aldryn_newsblog/cms_toolbar.py
@@ -72,9 +72,14 @@ class NewsBlogToolbar(CMSToolbar):
         view_name = self.request.resolver_match.view_name
         if (view_name == '{0}:article-detail'.format(config.namespace) and
                 self.request.user.has_perm('aldryn_newsblog.change_article')):
-
-            slug = self.request.resolver_match.kwargs['slug']
-            articles = Article.objects.translated(slug=slug)
+            kwargs = self.request.resolver_match.kwargs
+            articles = Article.objects
+            if hasattr(kwargs, 'slug'):
+                slug = kwargs['slug']
+                articles = articles.translated(slug=slug)
+            elif hasattr(kwargs, 'pk'):
+                pk = kwargs['pk']
+                articles = articles.filter(pk=pk)
             if articles.count() == 1:
                 menu.add_modal_item(_('Edit article'), admin_reverse(
                     'aldryn_newsblog_article_change', args=(

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -137,14 +137,24 @@ class Article(TranslatableModel):
         # not created the apphook yet, as some user work-flows involve creating
         # articles before the page exists.
         #
+        kwargs = {}
+        permalink_type = self.app_config.permalink_type
+        if 'y' in permalink_type:
+            kwargs.update(year=self.publishing_date.year)
+        if 'm' in permalink_type:
+            kwargs.update(month=self.publishing_date.month)
+        if 'd' in permalink_type:
+            kwargs.update(day=self.publishing_date.day)
+        if 'i' in permalink_type:
+            kwargs.update(pk=self.pk)
+        if 's' in permalink_type:
+            kwargs.update(
+                slug=self.safe_translation_getter('slug', any_language=True))
         try:
             return reverse(
                 '{namespace}:article-detail'.format(
                     namespace=self.app_config.namespace
-                ), kwargs={
-                    'slug': self.safe_translation_getter(
-                        'slug', any_language=True)
-                }
+                ), kwargs=kwargs
             )
         except:
             return ''  # Note NOT None here

--- a/aldryn_newsblog/south_migrations/0032_auto__add_field_newsblogconfig_permalink_type__add_unique_newsblogconf.py
+++ b/aldryn_newsblog/south_migrations/0032_auto__add_field_newsblogconfig_permalink_type__add_unique_newsblogconf.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'NewsBlogConfig.permalink_type'
+        db.add_column(u'aldryn_newsblog_newsblogconfig', 'permalink_type',
+                      self.gf('django.db.models.fields.CharField')(default=u'slug', max_length=8),
+                      keep_default=False)
+
+        # Adding unique constraint on 'NewsBlogConfig', fields ['namespace']
+        db.create_unique(u'aldryn_newsblog_newsblogconfig', ['namespace'])
+
+
+        # Changing field 'Article.app_config'
+        db.alter_column(u'aldryn_newsblog_article', 'app_config_id', self.gf('aldryn_apphooks_config.fields.AppHookConfigField')(to=orm['aldryn_newsblog.NewsBlogConfig']))
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'NewsBlogConfig', fields ['namespace']
+        db.delete_unique(u'aldryn_newsblog_newsblogconfig', ['namespace'])
+
+        # Deleting field 'NewsBlogConfig.permalink_type'
+        db.delete_column(u'aldryn_newsblog_newsblogconfig', 'permalink_type')
+
+
+        # Changing field 'Article.app_config'
+        db.alter_column(u'aldryn_newsblog_article', 'app_config_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['aldryn_newsblog.NewsBlogConfig']))
+
+    models = {
+        u'aldryn_categories.category': {
+            'Meta': {'object_name': 'Category'},
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'rgt': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'aldryn_newsblog.article': {
+            'Meta': {'ordering': "[u'-publishing_date']", 'object_name': 'Article'},
+            'app_config': ('aldryn_apphooks_config.fields.AppHookConfigField', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'categories': ('aldryn_categories.fields.CategoryManyToManyField', [], {'to': u"orm['aldryn_categories.Category']", 'symmetrical': 'False', 'blank': 'True'}),
+            'content': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'newsblog_article_content'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'featured_image': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['filer.Image']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'publishing_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'related': ('sortedm2m.fields.SortedManyToManyField', [], {'related_name': "'related_rel_+'", 'blank': 'True', 'to': u"orm['aldryn_newsblog.Article']"})
+        },
+        u'aldryn_newsblog.articletranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'slug'), (u'language_code', u'master')]", 'object_name': 'ArticleTranslation', 'db_table': "u'aldryn_newsblog_article_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'lead_in': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.Article']"}),
+            'meta_description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_keywords': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'search_data': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '234'})
+        },
+        u'aldryn_newsblog.newsblogarchiveplugin': {
+            'Meta': {'object_name': 'NewsBlogArchivePlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogarticlesearchplugin': {
+            'Meta': {'object_name': 'NewsBlogArticleSearchPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"}),
+            'max_articles': ('django.db.models.fields.PositiveIntegerField', [], {'default': '10'})
+        },
+        u'aldryn_newsblog.newsblogauthorsplugin': {
+            'Meta': {'object_name': 'NewsBlogAuthorsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogcategoriesplugin': {
+            'Meta': {'object_name': 'NewsBlogCategoriesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogconfig': {
+            'Meta': {'object_name': 'NewsBlogConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            'create_authors': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'unique': 'True', 'max_length': '100'}),
+            'paginate_by': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'permalink_type': ('django.db.models.fields.CharField', [], {'default': "u'slug'", 'max_length': '8'}),
+            'placeholder_base_sidebar': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_base_sidebar'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_base_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_base_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_detail_bottom': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_bottom'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_detail_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_detail_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_list_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_list_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_list_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_list_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'search_indexed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_newsblog.newsblogconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'NewsBlogConfigTranslation', 'db_table': "u'aldryn_newsblog_newsblogconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'max_length': '234'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.NewsBlogConfig']"})
+        },
+        u'aldryn_newsblog.newsblogfeaturedarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogFeaturedArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'article_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsbloglatestarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogLatestArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"}),
+            'latest_articles': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        u'aldryn_newsblog.newsblogrelatedplugin': {
+            'Meta': {'object_name': 'NewsBlogRelatedPlugin', '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogtagsplugin': {
+            'Meta': {'object_name': 'NewsBlogTagsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_newsblog']

--- a/aldryn_newsblog/south_migrations/0033_auto__add_field_newsblogconfig_non_permalink_handling.py
+++ b/aldryn_newsblog/south_migrations/0033_auto__add_field_newsblogconfig_non_permalink_handling.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'NewsBlogConfig.non_permalink_handling'
+        db.add_column(u'aldryn_newsblog_newsblogconfig', 'non_permalink_handling',
+                      self.gf('django.db.models.fields.SmallIntegerField')(default=302),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'NewsBlogConfig.non_permalink_handling'
+        db.delete_column(u'aldryn_newsblog_newsblogconfig', 'non_permalink_handling')
+
+
+    models = {
+        u'aldryn_categories.category': {
+            'Meta': {'object_name': 'Category'},
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'rgt': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        u'aldryn_newsblog.article': {
+            'Meta': {'ordering': "[u'-publishing_date']", 'object_name': 'Article'},
+            'app_config': ('aldryn_apphooks_config.fields.AppHookConfigField', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Person']", 'null': 'True', 'blank': 'True'}),
+            'categories': ('aldryn_categories.fields.CategoryManyToManyField', [], {'to': u"orm['aldryn_categories.Category']", 'symmetrical': 'False', 'blank': 'True'}),
+            'content': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'newsblog_article_content'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'featured_image': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['filer.Image']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_featured': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'publishing_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'related': ('sortedm2m.fields.SortedManyToManyField', [], {'related_name': "'related_rel_+'", 'blank': 'True', 'to': u"orm['aldryn_newsblog.Article']"})
+        },
+        u'aldryn_newsblog.articletranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'slug'), (u'language_code', u'master')]", 'object_name': 'ArticleTranslation', 'db_table': "u'aldryn_newsblog_article_translation'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'lead_in': ('djangocms_text_ckeditor.fields.HTMLField', [], {'default': "u''", 'blank': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.Article']"}),
+            'meta_description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_keywords': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            'meta_title': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'search_data': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '234'})
+        },
+        u'aldryn_newsblog.newsblogarchiveplugin': {
+            'Meta': {'object_name': 'NewsBlogArchivePlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogarticlesearchplugin': {
+            'Meta': {'object_name': 'NewsBlogArticleSearchPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"}),
+            'max_articles': ('django.db.models.fields.PositiveIntegerField', [], {'default': '10'})
+        },
+        u'aldryn_newsblog.newsblogauthorsplugin': {
+            'Meta': {'object_name': 'NewsBlogAuthorsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogcategoriesplugin': {
+            'Meta': {'object_name': 'NewsBlogCategoriesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogconfig': {
+            'Meta': {'object_name': 'NewsBlogConfig'},
+            'app_data': ('app_data.fields.AppDataField', [], {'default': "'{}'"}),
+            'create_authors': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'namespace': ('django.db.models.fields.CharField', [], {'default': 'None', 'unique': 'True', 'max_length': '100'}),
+            'non_permalink_handling': ('django.db.models.fields.SmallIntegerField', [], {'default': '302'}),
+            'paginate_by': ('django.db.models.fields.PositiveIntegerField', [], {'default': '5'}),
+            'permalink_type': ('django.db.models.fields.CharField', [], {'default': "u'slug'", 'max_length': '8'}),
+            'placeholder_base_sidebar': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_base_sidebar'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_base_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_base_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_detail_bottom': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_bottom'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_detail_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_detail_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_detail_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_list_footer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_list_footer'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'placeholder_list_top': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'aldryn_newsblog_list_top'", 'null': 'True', 'to': "orm['cms.Placeholder']"}),
+            'search_indexed': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'aldryn_newsblog.newsblogconfigtranslation': {
+            'Meta': {'unique_together': "[(u'language_code', u'master')]", 'object_name': 'NewsBlogConfigTranslation', 'db_table': "u'aldryn_newsblog_newsblogconfig_translation'"},
+            'app_title': ('django.db.models.fields.CharField', [], {'max_length': '234'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language_code': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            u'master': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'translations'", 'null': 'True', 'to': u"orm['aldryn_newsblog.NewsBlogConfig']"})
+        },
+        u'aldryn_newsblog.newsblogfeaturedarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogFeaturedArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'article_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsbloglatestarticlesplugin': {
+            'Meta': {'object_name': 'NewsBlogLatestArticlesPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"}),
+            'latest_articles': ('django.db.models.fields.IntegerField', [], {'default': '5'})
+        },
+        u'aldryn_newsblog.newsblogrelatedplugin': {
+            'Meta': {'object_name': 'NewsBlogRelatedPlugin', '_ormbases': ['cms.CMSPlugin']},
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_newsblog.newsblogtagsplugin': {
+            'Meta': {'object_name': 'NewsBlogTagsPlugin'},
+            'app_config': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_newsblog.NewsBlogConfig']"}),
+            'cmsplugin_ptr': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "u'+'", 'unique': 'True', 'primary_key': 'True', 'to': "orm['cms.CMSPlugin']"})
+        },
+        u'aldryn_people.group': {
+            'Meta': {'object_name': 'Group'},
+            'address': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'aldryn_people.person': {
+            'Meta': {'object_name': 'Person'},
+            'email': ('django.db.models.fields.EmailField', [], {'default': "u''", 'max_length': '75', 'blank': 'True'}),
+            'fax': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['aldryn_people.Group']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'phone': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'vcard_enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'visual': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['filer.Image']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'cms.cmsplugin': {
+            'Meta': {'object_name': 'CMSPlugin'},
+            'changed_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '15', 'db_index': 'True'}),
+            'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.CMSPlugin']", 'null': 'True', 'blank': 'True'}),
+            'placeholder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['cms.Placeholder']", 'null': 'True'}),
+            'plugin_type': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        },
+        'cms.placeholder': {
+            'Meta': {'object_name': 'Placeholder'},
+            'default_width': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slot': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['aldryn_newsblog']

--- a/aldryn_newsblog/urls.py
+++ b/aldryn_newsblog/urls.py
@@ -15,14 +15,29 @@ urlpatterns = patterns(
     url(r'^search/$',
         ArticleSearchResultsList.as_view(), name='article-search'),
 
-    url(r'^(?P<year>[0-9]{4})/$',
+    url(r'^(?P<year>\d{4})/$',
         YearArticleList.as_view(), name='article-list-by-year'),
-    url(r'^(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/$',
+    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/$',
         MonthArticleList.as_view(), name='article-list-by-month'),
-    url(r'^(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/(?P<day>[0-9]{1,2})/$',
+    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/$',
         DayArticleList.as_view(), name='article-list-by-day'),
 
+    # Various permalink styles that we support
+    # ----------------------------------------
+    # This supports permalinks with <article_pk>
+    # NOTE: We cannot support /year/month/pk, /year/pk, or /pk, since these
+    # patterns collide with the list/archive views, which we'd prefer to
+    # continue to support.
+    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<pk>\d+)/$',
+        ArticleDetail.as_view(), name='article-detail'),
+    # These support permalinks with <article_slug>
     url(r'^(?P<slug>\w[-\w]*)/$',
+        ArticleDetail.as_view(), name='article-detail'),
+    url(r'^(?P<year>\d{4})/(?P<slug>\w[-\w]*)/$',
+        ArticleDetail.as_view(), name='article-detail'),
+    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<slug>\w[-\w]*)/$',
+        ArticleDetail.as_view(), name='article-detail'),
+    url(r'^(?P<year>\d{4})/(?P<month>\d{1,2})/(?P<day>\d{1,2})/(?P<slug>\w[-\w]*)/$',
         ArticleDetail.as_view(), name='article-detail'),
 
     url(r'^author/(?P<author>\w[-\w]*)/$',


### PR DESCRIPTION
This PR supplies:

1. The ability for multiple types of urls to articles to be supported (at the same time, if desired).
2. The ability to change the canonical url pattern of articles system-wide.
3. The ability to change how the system will handle incoming requests for articles not using the canonical url.

By default, everything should work as it has in previous versions. Changes can be made on a per-apphook basis as the settings are managed in the app_config.