### PR TITLE
Switch Django get_language for CMS get_current_language to avoid Django ...

### DIFF
--- a/aldryn_newsblog/feeds.py
+++ b/aldryn_newsblog/feeds.py
@@ -3,12 +3,12 @@
 from django.contrib.sites.models import Site
 from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
-from django.utils.translation import (
-    get_language, get_language_from_request, ugettext as _)
+from django.utils.translation import get_language_from_request, ugettext as _
 
 from aldryn_apphooks_config.utils import get_app_instance
 from aldryn_categories.models import Category
 from aldryn_newsblog.models import Article
+from cms.utils.i18n import get_current_language
 
 
 class LatestArticlesFeed(Feed):
@@ -25,7 +25,7 @@ class LatestArticlesFeed(Feed):
         return _('Articles on {0}').format(Site.objects.get_current().name)
 
     def get_queryset(self):
-        language = get_language()
+        language = get_current_language()
         return Article.objects.published().active_translations(
             language
         ).namespace(self.namespace)

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -19,7 +19,7 @@ except ImportError:
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.text import slugify as default_slugify
 from django.utils.timezone import now
-from django.utils.translation import get_language, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from aldryn_apphooks_config.fields import AppHookConfigField
 from aldryn_categories.fields import CategoryManyToManyField
@@ -28,6 +28,7 @@ from aldryn_people.models import Person
 from aldryn_reversion.core import version_controlled_content
 from cms.models.fields import PlaceholderField
 from cms.models.pluginmodel import CMSPlugin
+from cms.utils.i18n import get_current_language
 from djangocms_text_ckeditor.fields import HTMLField
 from filer.fields.image import FilerImageField
 from parler.models import TranslatableModel, TranslatedFields
@@ -163,7 +164,7 @@ class Article(TranslatableModel):
         if not self.pk:
             return ''
         if language is None:
-            language = get_language()
+            language = get_current_language()
         if request is None:
             request = get_request(language=language)
         description = self.safe_translation_getter('lead_in')
@@ -290,7 +291,7 @@ class NewsBlogAuthorsPlugin(PluginEditModeMixin, NewsBlogCMSPlugin):
             SELECT COUNT(*)
             FROM aldryn_newsblog_article
             WHERE
-                aldryn_newsblog_article.author_id = 
+                aldryn_newsblog_article.author_id =
                     aldryn_people_person.id AND
                 aldryn_newsblog_article.app_config_id = %d"""
 
@@ -367,7 +368,7 @@ class NewsBlogFeaturedArticlesPlugin(PluginEditModeMixin, NewsBlogCMSPlugin):
         queryset = Article.objects
         if not self.get_edit_mode(request):
             queryset = queryset.published()
-        queryset = queryset.active_translations(get_language()).filter(
+        queryset = queryset.active_translations(get_current_language()).filter(
             app_config=self.app_config,
             is_featured=True,
         )
@@ -401,7 +402,7 @@ class NewsBlogLatestArticlesPlugin(PluginEditModeMixin, NewsBlogCMSPlugin):
         queryset = Article.objects
         if not self.get_edit_mode(request):
             queryset = queryset.published()
-        queryset = queryset.active_translations(get_language()).filter(
+        queryset = queryset.active_translations(get_current_language()).filter(
             app_config=self.app_config
         )
         return queryset[:self.latest_articles]

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -13,10 +13,11 @@ from django.core.files import File as DjangoFile
 from django.core.urlresolvers import reverse
 from django.test import TransactionTestCase
 from django.utils.timezone import now
-from django.utils.translation import get_language, override
+from django.utils.translation import override
 
 from aldryn_newsblog.models import Article, NewsBlogConfig
 from aldryn_newsblog.search_indexes import ArticleIndex
+from cms.utils.i18n import get_current_language
 from easy_thumbnails.files import get_thumbnailer
 from filer.models.imagemodels import Image
 from parler.tests.utils import override_parler_settings
@@ -482,7 +483,7 @@ class TestIndex(NewsBlogTestsMixin, TransactionTestCase):
         LANGUAGES = add_default_language_settings(PARLER_LANGUAGES_HIDE)
         with override_parler_settings(PARLER_LANGUAGES=LANGUAGES):
             with smart_override('de'):
-                language = get_language()
+                language = get_current_language()
                 # english-only article is excluded
                 qs = self.index.index_queryset(language)
                 self.assertEqual(qs.count(), 1)


### PR DESCRIPTION
Switch Django get_language for CMS get_current_language to avoid Django issue https://code.djangoproject.com/ticket/9340

This branch merges to 0.7.x version used in few projects. When merge I release a 0.8.x version with fixes.