### PR TITLE
Issues/respect redirect on fallback setting

### DIFF
--- a/aldryn_newsblog/cms_appconfig.py
+++ b/aldryn_newsblog/cms_appconfig.py
@@ -29,10 +29,9 @@ NON_PERMALINK_HANDLING = (
     (404, _('Return 404: Not Found')),
 )
 
-# TODO ovveride default if support for Django 1.6 will be dropped
+# TODO override default if support for Django 1.6 will be dropped
 TEMPLATE_PREFIX_CHOICES = getattr(
-    settings, 'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES',
-    [])
+    settings, 'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES', [])
 
 
 class NewsBlogConfig(TranslatableModel, AppHookConfig):
@@ -43,9 +42,11 @@ class NewsBlogConfig(TranslatableModel, AppHookConfig):
 
     permalink_type = models.CharField(_('permalink type'), max_length=8,
         blank=False, default='slug', choices=PERMALINK_CHOICES,
-        help_text=_('Choose the style of urls to use from the examples. (Note, all types are relative to apphook)'))
+        help_text=_('Choose the style of urls to use from the examples. '
+                    '(Note, all types are relative to apphook)'))
 
-    non_permalink_handling = models.SmallIntegerField(_('non-permalink handling'),
+    non_permalink_handling = models.SmallIntegerField(
+        _('non-permalink handling'),
         blank=False, default=302,
         choices=NON_PERMALINK_HANDLING,
         help_text=_('How to handle non-permalink urls?'))
@@ -118,6 +119,7 @@ class NewsBlogConfig(TranslatableModel, AppHookConfig):
 
 
 class NewsBlogConfigForm(AppDataForm):
-    default_published = forms.BooleanField(label=_(u'Post published by default'), required=False,
-                                           initial=getattr(settings, 'ALDRYN_NEWSBLOG_DEFAULT_PUBLISHED', True))
+    default_published = forms.BooleanField(
+        label=_(u'Post published by default'), required=False,
+        initial=getattr(settings, 'ALDRYN_NEWSBLOG_DEFAULT_PUBLISHED', True))
 setup_config(NewsBlogConfigForm, NewsBlogConfig)

--- a/aldryn_newsblog/cms_toolbar.py
+++ b/aldryn_newsblog/cms_toolbar.py
@@ -75,12 +75,11 @@ class NewsBlogToolbar(CMSToolbar):
             kwargs = self.request.resolver_match.kwargs
             articles = Article.objects
             if hasattr(kwargs, 'slug'):
-                slug = kwargs['slug']
-                articles = articles.translated(slug=slug)
+                articles = articles.translated(slug=kwargs['slug'])
             elif hasattr(kwargs, 'pk'):
-                pk = kwargs['pk']
-                articles = articles.filter(pk=pk)
-            if articles.count() == 1:
+                articles = articles.filter(pk=kwargs['pk'])
+            articles = articles.all()
+            if articles.count():
                 menu.add_modal_item(_('Edit article'), admin_reverse(
                     'aldryn_newsblog_article_change', args=(
                         articles[0].pk,)), active=True,)

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
@@ -29,7 +28,7 @@ from aldryn_translation_tools.models import TranslationHelperMixin
 
 from cms.models.fields import PlaceholderField
 from cms.models.pluginmodel import CMSPlugin
-from cms.utils.i18n import get_current_language
+from cms.utils.i18n import get_current_language, get_redirect_on_fallback
 from djangocms_text_ckeditor.fields import HTMLField
 from filer.fields.image import FilerImageField
 from parler.models import TranslatableModel, TranslatedFields
@@ -159,7 +158,9 @@ class Article(TranslationHelperMixin, TranslatableModel):
             slug, lang = self.known_translation_getter(
                 'slug', default=None, language_code=language)
             if slug and lang:
-                language = lang
+                site_id = getattr(settings, 'SITE_ID', None)
+                if get_redirect_on_fallback(language, site_id):
+                    language = lang
                 kwargs.update(slug=slug)
 
         if self.app_config and self.app_config.namespace:

--- a/aldryn_newsblog/tests/__init__.py
+++ b/aldryn_newsblog/tests/__init__.py
@@ -25,6 +25,34 @@ TESTS_STATIC_ROOT = os.path.abspath(os.path.join(TESTS_ROOT, 'static'))
 
 class NewsBlogTestsMixin(object):
 
+    NO_REDIRECT_CMS_SETTINGS =  {
+        1: [
+            {
+                'code': 'de',
+                'name': 'Deutsche',
+                'fallbacks': ['en', ]  # FOR TESTING DO NOT ADD 'fr' HERE
+            },
+            {
+                'code': 'fr',
+                'name': 'Française',
+                'fallbacks': ['en', ]  # FOR TESTING DO NOT ADD 'de' HERE
+            },
+            {
+                'code': 'en',
+                'name': 'English',
+                'fallbacks': ['de', 'fr', ]
+            },
+            {
+                'code': 'it',
+                'name': 'Italiano',
+                'fallbacks': ['fr', ]  # FOR TESTING, LEAVE AS ONLY 'fr'
+            },
+        ],
+        'default': {
+            'redirect_on_fallback': False,
+        }
+    }
+
     @staticmethod
     def reload(node):
         """NOTE: django-treebeard requires nodes to be reloaded via the Django

--- a/aldryn_newsblog/tests/test_i18n.py
+++ b/aldryn_newsblog/tests/test_i18n.py
@@ -31,11 +31,11 @@ class TestI18N(NewsBlogTestCase):
         # to, but has fallbacks defined, we should get EN
         self.assertEquals(article.get_absolute_url(language='fr'), '/en/page/god-save-queen/')
 
+        # With settings changed to 'redirect_on_fallback': False, test again.
+        with self.settings(CMS_LANGUAGES=self.NO_REDIRECT_CMS_SETTINGS):
+            self.assertEquals(article.get_absolute_url(language='fr'), '/fr/page/god-save-queen/')
+
         # Now, let's request a language that has a fallback defined, but it is
         # not available either (should raise NoReverseMatch)
         with self.assertRaises(NoReverseMatch):
             article.get_absolute_url(language='it')
-
-        # Now let's test a non-existant language. We want it to return the
-        # default language here, EN in this case.
-        self.assertEquals(article.get_absolute_url(language='qq'), '/en/page/god-save-queen/')

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -212,6 +212,20 @@ class TestTranslationFallbacks(NewsBlogTestCase):
                 # This is a redirect to the new language
                 self.assertEquals(response.status_code, 302)
 
+            # Test again with redirect_on_fallback = False
+            with self.settings(CMS_LANGUAGES=self.NO_REDIRECT_CMS_SETTINGS):
+                language = settings.LANGUAGES[1][0]
+                with switch_language(article, language):
+                    url = reverse(
+                        'aldryn_newsblog:article-detail',
+                        kwargs={'slug': article.slug, }
+                    )
+                    self.assertNotEquals(url, url_one)
+                    response = self.client.get(url)
+                    # This is a redirect to the new language
+                    self.assertEquals(response.status_code, 200)
+
+
     def test_article_detail_not_translated_no_fallback(self):
         """
         If the fallback is disabled, article is available only in the

--- a/test_settings.py
+++ b/test_settings.py
@@ -57,7 +57,7 @@ HELPER_SETTINGS = {
             {'code': 'en', },
         ),
         'default': {
-            'hide_untranslated': False,
+            'hide_untranslated': True, # PLEASE DO NOT CHANGE THIS
         }
     },
     'SITE_ID': 1,
@@ -82,8 +82,11 @@ HELPER_SETTINGS = {
                 'code': 'it',
                 'name': 'Italiano',
                 'fallbacks': ['fr', ]  # FOR TESTING, LEAVE AS ONLY 'fr'
-            }
-        ]
+            },
+        ],
+        'default': {
+            'redirect_on_fallback': True,  # PLEASE DO NOT CHANGE THIS
+        }
     },
     #
     # NOTE: The following setting `PARLER_ENABLE_CACHING = False` is required


### PR DESCRIPTION
Respects the CMS_SETTINGS setting of 'redirect_on_fallback=False'. NOTE: It is recommended that if you use this in your settings, that you also set 'Non-permalink handling' in your appconfig to "Allow".