### PR TITLE
Add a dependency on filer when a filer field is introduced.

### DIFF
--- a/aldryn_newsblog/south_migrations/0011_auto__add_field_article_featured_image.py
+++ b/aldryn_newsblog/south_migrations/0011_auto__add_field_article_featured_image.py
@@ -9,6 +9,10 @@ from aldryn_newsblog.utils.migration import rename_tables_old_to_new, rename_tab
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('filer', '0001_initial'),
+    )
+
     def forwards(self, orm):
         rename_tables_old_to_new(db)
         # Adding field 'Article.featured_image'


### PR DESCRIPTION
Migration 11 introduces a filer-image field, which is only usable if the db schema for filer is already in place. Without a migration dependency this migration might run (and fail) before the filer migrations are run. This patch fixes the problem by forcing a dependency on the initial filer migration.