### PR TITLE
fix toolbar issue with watch models

### DIFF
--- a/aldryn_newsblog/cms_toolbar.py
+++ b/aldryn_newsblog/cms_toolbar.py
@@ -16,7 +16,8 @@ from .cms_appconfig import NewsBlogConfig
 
 @toolbar_pool.register
 class NewsBlogToolbar(CMSToolbar):
-    watch_models = (Article, )
+    watch_models = [Article, ]  # must be a list, not a tuple
+                                # see https://github.com/divio/django-cms/issues/4135
     supported_apps = ('aldryn_newsblog',)
 
     def __get_newsblog_config(self):

--- a/aldryn_newsblog/cms_toolbar.py
+++ b/aldryn_newsblog/cms_toolbar.py
@@ -16,8 +16,9 @@ from .cms_appconfig import NewsBlogConfig
 
 @toolbar_pool.register
 class NewsBlogToolbar(CMSToolbar):
-    watch_models = [Article, ]  # must be a list, not a tuple
-                                # see https://github.com/divio/django-cms/issues/4135
+    # watch_models must be a list, not a tuple
+    # see https://github.com/divio/django-cms/issues/4135
+    watch_models = [Article, ]
     supported_apps = ('aldryn_newsblog',)
 
     def __get_newsblog_config(self):

--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -520,7 +520,8 @@ def update_seach_index(sender, instance, **kwargs):
     perform simple searches even without Haystack, etc.
     """
     if issubclass(instance.__class__, CMSPlugin):
-        placeholder = getattr(instance, '_placeholder_cache', None) or instance.placeholder
+        placeholder = (getattr(instance, '_placeholder_cache', None)
+                       or instance.placeholder)
         if hasattr(placeholder, '_attached_model_cache'):
             if placeholder._attached_model_cache == Article:
                 article = placeholder._attached_model_cache.objects.get(


### PR DESCRIPTION
Without this change, you'll get a ``*** TypeError: can only concatenate list (not "tuple") to list`` when watch_models is combined with existing menus.

This is a workaround until https://github.com/divio/django-cms/issues/4135 is fixed and aldryn-newsblog no longer needs to support cms versions prior to the version with that fix.