### PR TITLE
Update documentation to use the proper name Aldryn News & Blog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,7 +33,7 @@ CHANGELOG
 * Add "magic" migrations to move from old-style CMS plugin table naming to new
   for users using older versions of CMS.
 * Post a deprecation notice about supporting only CMS 3.0+ from version 1.0.0
-  of Aldryn NewsBlog.
+  of Aldryn News & Blog.
 
 
 0.9.2 (2015-04-21)

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 |PyPI Version| |Build Status| |Coverage Status| |codeclimate| |requires_io|
 
-===============
-Aldryn Newsblog
-===============
+==================
+Aldryn News & Blog
+==================
 
 NOTICE: ::
 
@@ -41,8 +41,8 @@ Description
 
 A combined news/weblog application for Aldryn and django CMS.
 
-Aldryn NewsBlog is intended to serve as a model of good practice for development
-of django CMS and Aldryn applications.
+Aldryn News & Blog is intended to serve as a model of good practice for
+development of django CMS and Aldryn applications.
 
 
 --------------------
@@ -62,7 +62,7 @@ Aldryn Platform Users
 
 2) Go to **Apps** > **Install App**
 
-3) Click **Install** next to the **NewsBlog** app.
+3) Click **Install** next to the **News & Blog** app.
 
 4) Redeploy the site.
 
@@ -154,8 +154,8 @@ Settings
 ~~~~~~~~
 
 The flag `ALDRYN_NEWSBLOG_SEARCH` can be set to `False` in settings if indexing
-should be globally disabled for NewsBlog. When this is `False`, it overrides
-the setting in the application configuration on each apphook.
+should be globally disabled for Aldryn News & Blog. When this is `False`, it
+overrides the setting in the application configuration on each apphook.
 
 If aldryn-search, Haystack, et al, are not installed, this setting does nothing.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -2,7 +2,7 @@
 Development & community
 #######################
 
-Aldryn NewsBlog is an open-source project.
+Aldryn News & Blog is an open-source project.
 
 You don't need to be an expert developer to make a valuable contribution - all you need is a little
 knowledge, and a willingness to follow the contribution guidelines.
@@ -11,25 +11,25 @@ knowledge, and a willingness to follow the contribution guidelines.
 Divio AG
 ********
 
-Aldryn NewsBlog was created at `Divio AG <https://divio.ch/>`_ of Zürich, Switzerland and is
+Aldryn News & Blog was created at `Divio AG <https://divio.ch/>`_ of Zürich, Switzerland and is
 released under a BSD licence.
 
-Aldryn NewsBlog is compatible with Divio's `Aldryn <http://aldryn.com>`_ cloud-based `django CMS
+Aldryn News & Blog is compatible with Divio's `Aldryn <http://aldryn.com>`_ cloud-based `django CMS
 <http://django-cms.org>`_ hosting platform, and therefore with any standard django CMS
 installation. The additional requirements of an Aldryn application do not preclude its use with any
 other django CMS deployment.
 
-Divio is committed to Aldryn NewsBlog as a high-quality application that helps set standards for
+Divio is committed to Aldryn News & Blog as a high-quality application that helps set standards for
 others in the Aldryn/django CMS ecosystem, and as a healthy open source project.
 
-Divio maintains overall control of the `Aldryn NewsBlog repository
+Divio maintains overall control of the `Aldryn News & Blog repository
 <https://github.com/aldryn/aldryn-newsblog>`_.
 
 ********************
 Standards & policies
 ********************
 
-Aldryn NewsBlog is a django CMS application, and shares much of django CMS's standards and policies.
+Aldryn News & Blog is a django CMS application, and shares much of django CMS's standards and policies.
 
 These include:
 
@@ -43,14 +43,14 @@ These include:
   activity
 
 Please familiarise yourself with this documentation if you'd like to contribute to
-Aldryn NewsBlog.
+Aldryn News & Blog.
 
 *************
 Running tests
 *************
 
-Aldryn NewsBlog uses `django CMS Helper <https://github.com/nephila/djangocms-helper>`_ to run its
-test suite.
+Aldryn News & Blog uses `django CMS Helper <https://github.com/nephila/djangocms-helper>`_
+to run its test suite.
 
 There's more than one way to do this, but here's one to help you get started::
 
@@ -61,7 +61,7 @@ There's more than one way to do this, but here's one to help you get started::
     cd test-aldryn-newsblog/
     source bin/activate
 
-    # get Aldryn NewsBlog from GitHub
+    # get Aldryn News & Blog from GitHub
     git clone git@github.com:aldryn/aldryn-newsblog.git
 
     # downgrade pip to a version < 6

--- a/docs/how_to/index.rst
+++ b/docs/how_to/index.rst
@@ -2,5 +2,5 @@
 How-to guides
 #############
 
-These guides presuppose some familiarity with Aldryn NewsBlog. They cover some of the same
-territory as the :doc:`/introduction/index`, but in more detail.
+These guides presuppose some familiarity with Aldryn News & Blog. They cover
+some of the same territory as the :doc:`/introduction/index`, but in more detail.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-###############
-Aldryn NewsBlog
-###############
+##################
+Aldryn News & Blog
+##################
 
 
-Aldryn NewsBlog is an `Aldryn <http://aldryn.com>`_-compatible news and weblog application for
-`django CMS <http://django-cms.org>`_.
+Aldryn News & Blog is an `Aldryn <http://aldryn.com>`_-compatible news and
+weblog application for `django CMS <http://django-cms.org>`_.
 
 **Web content editors** looking for documentation on how to use the editing
 interface should refer to our :doc:`/user/index` section.

--- a/docs/introduction/basic_usage.rst
+++ b/docs/introduction/basic_usage.rst
@@ -2,8 +2,9 @@
 Basic usage
 ###########
 
-Aldryn NewsBlog works the way that many django-CMS-compatible applications to. It expects you to
-create a new page for it in django CMS, and then attach it to that page with an Apphook.
+Aldryn News & Blog works the way that many django-CMS-compatible applications to.
+It expects you to create a new page for it in django CMS, and then attach it to
+that page with an Apphook.
 
 ***************
 Getting started

--- a/docs/introduction/installation.rst
+++ b/docs/introduction/installation.rst
@@ -11,8 +11,8 @@ or::
     pip install -e git+https://github.com/aldryn/aldryn-newsblog.git#egg=aldryn-newsblog
 
 If you need to start a new project, we recommend that first you use the `django CMS Installer
-<http://djangocms-installer.readthedocs.org>`_ to create it, and then install Aldryn NewsBlog on
-top of that.
+<http://djangocms-installer.readthedocs.org>`_ to create it, and then install
+Aldryn News & Blog on top of that.
 
 In your project's ``settings.py`` make sure you have all of::
 

--- a/docs/topics/index.rst
+++ b/docs/topics/index.rst
@@ -2,5 +2,6 @@
 Key topics
 ##########
 
-This section explains and analyses some key concepts in Aldryn NewsBlog. It's less concerned with
-explaining *how to do things* than with helping you understand how it works.
+This section explains and analyses some key concepts in Aldryn News & Blog.
+It's less concerned with explaining *how to do things* than with helping you
+understand how it works.

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -1,6 +1,7 @@
-#####################
-Using Aldryn NewsBlog
-#####################
+########################
+Using Aldryn News & Blog
+########################
 
-The documentation in these two sections focuses on the basics of content creation and editing using
-Aldryn NewsBlog. It's suitable for non-technical and technical audiences alike.
+The documentation in these two sections focuses on the basics of content
+creation and editing using Aldryn News & Blog. It's suitable for non-technical
+and technical audiences alike.


### PR DESCRIPTION
This patch addresses #226, changing textual references from NewsBlog to News & Blog.