### PR TITLE
Feature/remove warnings

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -45,6 +45,7 @@ class ArticleAdminForm(TranslatableModelForm):
 
     class Meta:
         model = models.Article
+        fields = '__all__'
 
     def __init__(self, *args, **kwargs):
         super(ArticleAdminForm, self).__init__(*args, **kwargs)

--- a/aldryn_newsblog/managers.py
+++ b/aldryn_newsblog/managers.py
@@ -29,12 +29,12 @@ class ArticleQuerySet(QuerySetMixin, TranslatableQuerySet):
 
 
 class RelatedManager(ManagerMixin, TranslatableManager):
-    def get_query_set(self):
+    def get_queryset(self):
         qs = ArticleQuerySet(self.model, using=self.db)
         return qs.select_related('featured_image')
 
     def published(self):
-        return self.get_query_set().published()
+        return self.get_queryset().published()
 
     def get_months(self, request, namespace):
         """


### PR DESCRIPTION
this removes the following warnings:

```
/Users/finalangel/Sites/aldryn/aldryn-newsblog/aldryn_newsblog/managers.py:31: RemovedInDjango18Warning: `RelatedManager.get_query_set` method should be renamed `get_queryset`.
  class RelatedManager(ManagerMixin, TranslatableManager):
```

```
/Users/finalangel/Sites/django-cms-demo/env/lib/python2.7/site-packages/parler/forms.py:163: RemovedInDjango18Warning: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is deprecated - form PersonForm needs updating
  return super(TranslatableModelFormMetaclass, mcs).__new__(mcs, name, bases, attrs)
```