### PR TITLE
missing migration

### DIFF
--- a/aldryn_newsblog/migrations/0004_auto_20150622_1606.py
+++ b/aldryn_newsblog/migrations/0004_auto_20150622_1606.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aldryn_newsblog', '0003_auto_20150422_1921'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='newsblogconfig',
+            name='template_prefix',
+            field=models.CharField(max_length=20, null=True, verbose_name='Prefix for template dirs', blank=True),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
there is apparently a missing migration, when working with the latest version I created:

````
Migrations for 'aldryn_newsblog':
  0004_auto_20150622_1606.py:
    - Alter field template_prefix on newsblogconfig
```

because the following warning shows up:

```
  Your models have changes that are not yet reflected in a migration, and so won't be applied.
  Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.
```