### PR TITLE
Django 1.8: bump versions, tox init, test settings and requirements updates.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,7 @@ from aldryn_newsblog import __version__
 REQUIREMENTS = [
     'Django>=1.6,<1.9',
     'aldryn-apphooks-config>=0.2.4',
-    # please uncomment and update to latest aldryn-boilerplates
-    # which has 1.8 support (currently not released on pipi)
-    # instead setup direct install it is included in test_requirements/base.txt
-    # 'aldryn-boilerplates>=0.6.0',
+    'aldryn-boilerplates>=0.7.2',
     'aldryn-categories',
     'aldryn-common>=0.1.3',
     'aldryn-people>=0.5.2',

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,12 @@ from setuptools import setup, find_packages
 from aldryn_newsblog import __version__
 
 REQUIREMENTS = [
-    'Django>=1.6,<1.8',
+    'Django>=1.6,<1.9',
     'aldryn-apphooks-config>=0.2.4',
-    'aldryn-boilerplates>=0.6.0',
+    # please uncomment and update to latest aldryn-boilerplates
+    # which has 1.8 support (currently not released on pipi)
+    # instead setup direct install it is included in test_requirements/base.txt
+    # 'aldryn-boilerplates>=0.6.0',
     'aldryn-categories',
     'aldryn-common>=0.1.3',
     'aldryn-people>=0.5.2',

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -3,7 +3,7 @@ aldryn-apphook-reload
 coverage>=3.7.1
 dj-database-url
 django-classy-tags
-django-mptt<0.7.0  # rq.filter: <0.7.0
+django-mptt<0.8.0  # rq.filter: <0.8.0
 django-haystack
 django-sekizai
 django-treebeard>=2.0

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,4 +1,4 @@
 django>=1.8,<1.9
 django-reversion>=1.8.2,<1.9
-
+https://github.com/aldryn/aldryn-boilerplates/archive/master.zip
 -r base.txt

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,4 +1,4 @@
 django>=1.8,<1.9
 django-reversion>=1.8.2,<1.9
-https://github.com/aldryn/aldryn-boilerplates/archive/master.zip
+
 -r base.txt

--- a/test_settings.py
+++ b/test_settings.py
@@ -176,7 +176,7 @@ elif django_version >= LooseVersion('1.8.0'):
                     ],
                     'loaders': [
                         'django.template.loaders.filesystem.Loader',
-                        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
+                        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',  # flake8: noqa
                         'django.template.loaders.app_directories.Loader',
                         'django.template.loaders.eggs.Loader',
                     ],

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from distutils.version import LooseVersion
+from django import get_version
 
 import os
 
+django_version = LooseVersion(get_version())
 
 HELPER_SETTINGS = {
     'TIME_ZONE': 'Europe/Zurich',
@@ -28,24 +31,12 @@ HELPER_SETTINGS = {
         'sortedm2m',
         'taggit',
     ],
-    'TEMPLATE_DIRS': (
-        os.path.join(
-            os.path.dirname(__file__),
-            'aldryn_newsblog', 'tests', 'templates'), ),
     'STATICFILES_FINDERS': [
         'django.contrib.staticfiles.finders.FileSystemFinder',
         # important! place right before:
         #     django.contrib.staticfiles.finders.AppDirectoriesFinder
         'aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder',
         'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    ],
-    'TEMPLATE_LOADERS': [
-        'django.template.loaders.filesystem.Loader',
-        # important! place right before:
-        #     django.template.loaders.app_directories.Loader
-        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
-        'django.template.loaders.app_directories.Loader',
-        'django.template.loaders.eggs.Loader',
     ],
     'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES': [('dummy', 'dummy'), ],
     'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
@@ -139,6 +130,61 @@ HELPER_SETTINGS = {
     #     }
     # }
 }
+
+if django_version < LooseVersion('1.8.0'):
+    HELPER_SETTINGS.update({
+        'CONTEXT_PROCESSORS': [
+            'aldryn_boilerplates.context_processors.boilerplate',
+        ],
+        'TEMPLATE_DIRS': (
+            os.path.join(
+                os.path.dirname(__file__),
+                'aldryn_newsblog', 'tests', 'templates'), ),
+        'TEMPLATE_LOADERS': [
+            'django.template.loaders.filesystem.Loader',
+            # important! place right before:
+            #     django.template.loaders.app_directories.Loader
+            'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
+            'django.template.loaders.app_directories.Loader',
+            'django.template.loaders.eggs.Loader',
+        ],
+    })
+elif django_version >= LooseVersion('1.8.0'):
+    HELPER_SETTINGS.update({
+        'TEMPLATES': [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [
+                    os.path.join(
+                        os.path.dirname(__file__),
+                        'aldryn_newsblog', 'tests', 'templates'),
+                ],
+                'OPTIONS': {
+                    'context_processors': [
+                        'django.contrib.auth.context_processors.auth',
+                        'django.contrib.messages.context_processors.messages',
+                        'django.core.context_processors.i18n',
+                        'django.core.context_processors.debug',
+                        'django.core.context_processors.request',
+                        'django.core.context_processors.media',
+                        'django.core.context_processors.csrf',
+                        'django.core.context_processors.tz',
+                        'sekizai.context_processors.sekizai',
+                        'django.core.context_processors.static',
+                        'cms.context_processors.cms_settings',
+                        'aldryn_boilerplates.context_processors.boilerplate',
+                    ],
+                    'loaders': [
+                        'django.template.loaders.filesystem.Loader',
+                        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
+                        'django.template.loaders.app_directories.Loader',
+                        'django.template.loaders.eggs.Loader',
+                    ],
+                },
+            },
+        ]
+    })
+
 
 # This set of MW classes should work for Django 1.6 and 1.7.
 MIDDLEWARE_CLASSES_17 = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26,py27}-dj16-{sqlite,mysql,postgres}-cms{30,31}, py27-dj17-{sqlite,mysql,postgres}-cms{30,31}, flake8
+envlist = {py26,py27}-dj16-{sqlite,mysql,postgres}-cms{30,31}, py27-dj17-{sqlite,mysql,postgres}-cms{30,31}, py27-dj18-{sqlite,mysql,postgres}-cms{30,31}, flake8
 
 [testenv]
 passenv =
@@ -17,6 +17,7 @@ whitelist_externals =
 deps =
     dj16: -rtest_requirements/django-1.6.txt
     dj17: -rtest_requirements/django-1.7.txt
+    dj18: -rtest_requirements/django-1.8.txt
     mysql: MySQL-python
     postgres: psycopg2
     cms30: django-cms<3.1  # rq.filter: <3.1


### PR DESCRIPTION
WARNING: aldryn-boilerplates are commented out with additional info. Please fix that after aldryn-boilerplates new release which should include https://github.com/aldryn/aldryn-boilerplates/pull/12 (merged to master)