### PR TITLE
Django 1.8: fix FE test cases, use unreleased djangocms-helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,8 @@ env:
   matrix:
     - TOXENV=flake8
     - TOXENV=py27-dj18-postgres-cms31
-    - TOXENV=py27-dj18-postgres-cms30
     - TOXENV=py27-dj18-mysql-cms31
-    - TOXENV=py27-dj18-mysql-cms30
     - TOXENV=py27-dj18-sqlite-cms31
-    - TOXENV=py27-dj18-sqlite-cms30
     - TOXENV=py27-dj17-sqlite-cms31
     - TOXENV=py27-dj17-sqlite-cms30
     - TOXENV=py27-dj16-sqlite-cms31

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -8,7 +8,10 @@ django-haystack
 django-sekizai
 django-treebeard>=2.0
 djangocms-admin-style
-djangocms-helper>=0.7
+# djangocms-helper has issues with management command which is fixed but
+# not released yet, so use develop branch temporary.
+# TODO: please replace with a release >0.8.0 or move back to base.txt
+https://github.com/nephila/djangocms-helper/archive/develop.zip
 djangocms_text_ckeditor
 docopt
 flake8

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -10,7 +10,7 @@ django-treebeard>=2.0
 djangocms-admin-style
 # djangocms-helper has issues with management command which is fixed but
 # not released yet, so use develop branch temporary.
-# TODO: please replace with a release >0.8.0 or move back to base.txt
+# TODO: please replace with a release >0.9.0
 https://github.com/nephila/djangocms-helper/archive/develop.zip
 djangocms_text_ckeditor
 docopt

--- a/test_settings.py
+++ b/test_settings.py
@@ -17,9 +17,7 @@ HELPER_SETTINGS = {
     'INSTALLED_APPS': [
         'aldryn_apphook_reload',
         'aldryn_apphooks_config',
-        'aldryn_boilerplates',
         'aldryn_categories',
-        'aldryn_newsblog',
         'aldryn_people',
         'aldryn_reversion',
         'djangocms_text_ckeditor',
@@ -31,13 +29,11 @@ HELPER_SETTINGS = {
         'sortedm2m',
         'taggit',
     ],
-    'STATICFILES_FINDERS': [
-        'django.contrib.staticfiles.finders.FileSystemFinder',
-        # important! place right before:
-        #     django.contrib.staticfiles.finders.AppDirectoriesFinder
-        'aldryn_boilerplates.staticfile_finders.AppDirectoriesFinder',
-        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    ],
+    'TEMPLATE_DIRS': (
+        os.path.join(
+            os.path.dirname(__file__),
+            'aldryn_newsblog', 'tests', 'templates'),
+    ),
     'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES': [('dummy', 'dummy'), ],
     'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     # app-specific
@@ -131,60 +127,6 @@ HELPER_SETTINGS = {
     # }
 }
 
-if django_version < LooseVersion('1.8.0'):
-    HELPER_SETTINGS.update({
-        'CONTEXT_PROCESSORS': [
-            'aldryn_boilerplates.context_processors.boilerplate',
-        ],
-        'TEMPLATE_DIRS': (
-            os.path.join(
-                os.path.dirname(__file__),
-                'aldryn_newsblog', 'tests', 'templates'), ),
-        'TEMPLATE_LOADERS': [
-            'django.template.loaders.filesystem.Loader',
-            # important! place right before:
-            #     django.template.loaders.app_directories.Loader
-            'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',
-            'django.template.loaders.app_directories.Loader',
-            'django.template.loaders.eggs.Loader',
-        ],
-    })
-elif django_version >= LooseVersion('1.8.0'):
-    HELPER_SETTINGS.update({
-        'TEMPLATES': [
-            {
-                'BACKEND': 'django.template.backends.django.DjangoTemplates',
-                'DIRS': [
-                    os.path.join(
-                        os.path.dirname(__file__),
-                        'aldryn_newsblog', 'tests', 'templates'),
-                ],
-                'OPTIONS': {
-                    'context_processors': [
-                        'django.contrib.auth.context_processors.auth',
-                        'django.contrib.messages.context_processors.messages',
-                        'django.core.context_processors.i18n',
-                        'django.core.context_processors.debug',
-                        'django.core.context_processors.request',
-                        'django.core.context_processors.media',
-                        'django.core.context_processors.csrf',
-                        'django.core.context_processors.tz',
-                        'sekizai.context_processors.sekizai',
-                        'django.core.context_processors.static',
-                        'cms.context_processors.cms_settings',
-                        'aldryn_boilerplates.context_processors.boilerplate',
-                    ],
-                    'loaders': [
-                        'django.template.loaders.filesystem.Loader',
-                        'aldryn_boilerplates.template_loaders.AppDirectoriesLoader',  # flake8: noqa
-                        'django.template.loaders.app_directories.Loader',
-                        'django.template.loaders.eggs.Loader',
-                    ],
-                },
-            },
-        ]
-    })
-
 
 # This set of MW classes should work for Django 1.6 and 1.7.
 MIDDLEWARE_CLASSES_17 = [
@@ -207,7 +149,9 @@ HELPER_SETTINGS['MIDDLEWARE_CLASSES'] = MIDDLEWARE_CLASSES_17
 
 def run():
     from djangocms_helper import runner
-    runner.cms('aldryn_newsblog')
+    # --boilerplate option will ensure correct boilerplate settings are
+    # added to settings
+    runner.cms('aldryn_newsblog', extra_args=['--boilerplate'])
 
 if __name__ == "__main__":
     run()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py27-dj{18,17,16}-{postgres,mysql,sqlite}-cms{31,30}, py26-dj16-{postgres,mysql,sqlite}-cms{31,30}
+envlist = flake8, py27-dj{18}-{postgres,mysql,sqlite}-cms{31}, py27-dj{17,16}-{postgres,mysql,sqlite}-cms{31,30}, py26-dj16-{postgres,mysql,sqlite}-cms{31,30}
 
 [testenv]
 passenv =


### PR DESCRIPTION
Also note that cms 3.0 does not supports django 1.8