### PR TITLE
Fix NewsblogConfig registration with aldryn-reversions. simple test case

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -6,7 +6,6 @@ from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _
 from cms.admin.placeholderadmin import (
     FrontendEditableAdminMixin,
-    PlaceholderAdminMixin,
 )
 from parler.forms import TranslatableModelForm
 from parler.admin import TranslatableAdmin

--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -153,6 +153,7 @@ admin.site.register(models.Article, ArticleAdmin)
 
 class NewsBlogConfigAdmin(
     AllTranslationsMixin,
+    VersionedPlaceholderAdminMixin,
     PlaceholderAdminMixin,
     BaseAppHookConfig,
     TranslatableAdmin

--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -154,7 +154,6 @@ admin.site.register(models.Article, ArticleAdmin)
 class NewsBlogConfigAdmin(
     AllTranslationsMixin,
     VersionedPlaceholderAdminMixin,
-    PlaceholderAdminMixin,
     BaseAppHookConfig,
     TranslatableAdmin
 ):

--- a/aldryn_newsblog/cms_appconfig.py
+++ b/aldryn_newsblog/cms_appconfig.py
@@ -119,6 +119,10 @@ class NewsBlogConfig(TranslatableModel, AppHookConfig):
     def get_app_title(self):
         return getattr(self, 'app_title', _('untitled'))
 
+    class Meta:
+        verbose_name = 'config'
+        verbose_name_plural = 'configs'
+
 
 class NewsBlogConfigForm(AppDataForm):
     default_published = forms.BooleanField(

--- a/aldryn_newsblog/cms_appconfig.py
+++ b/aldryn_newsblog/cms_appconfig.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from aldryn_apphooks_config.utils import setup_config
 from aldryn_apphooks_config.models import AppHookConfig
+from aldryn_reversion.core import version_controlled_content
 from app_data import AppDataForm
 from cms.models.fields import PlaceholderField
 from parler.models import TranslatableModel
@@ -34,6 +35,7 @@ TEMPLATE_PREFIX_CHOICES = getattr(
     settings, 'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES', [])
 
 
+@version_controlled_content
 class NewsBlogConfig(TranslatableModel, AppHookConfig):
     """Adds some translatable, per-app-instance fields."""
     translations = TranslatedFields(


### PR DESCRIPTION
Newsblog config was not registered with aldryn-reversions correctly, which was leading to issues while restoring article, and it was impossible to recover deleted newsblog config.