### PR TITLE
Fix app config reversion registration.

### DIFF
--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -65,7 +65,7 @@ SQL_IS_TRUE = {
 
 
 @python_2_unicode_compatible
-@version_controlled_content
+@version_controlled_content(follow=['app_config'])
 class Article(TranslationHelperMixin, TranslatableModel):
     # when True, updates the article's search_data field
     # whenever the article is saved or a plugin is saved


### PR DESCRIPTION
Prevent from Integrity error if NewsblogConfig was deleted.

This will include Newsblog Config into the revision, otherwise we might end up with issues.