### PR TITLE
adds missing requirement python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ REQUIREMENTS = [
     'lxml',
     'pytz',
     'six',
+    'python-dateutil',
 ]
 
 # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
wonder how this never was picked up before. was introduced in code almost a year ago. most likely there's another package in the testsuite that already install ``python-dateutil``