### PR TITLE
Respect language fallback settings in views, test cases for fallbacks.

### DIFF
--- a/aldryn_newsblog/cms_wizards.py
+++ b/aldryn_newsblog/cms_wizards.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.utils.translation import ugettext_lazy as _
 from django import forms
-from django.core.urlresolvers import reverse, NoReverseMatch
 
 from cms.api import add_plugin
 from cms.utils import permissions
@@ -16,6 +15,7 @@ from parler.forms import TranslatableModelForm
 
 from .cms_appconfig import NewsBlogConfig
 from .models import Article
+from .utils.utilities import is_valid_namespace
 
 
 def get_published_app_configs():
@@ -24,13 +24,10 @@ def get_published_app_configs():
     """
     published_configs = []
     for config in NewsBlogConfig.objects.iterator():
-        try:
-            reverse('{0}:article-list'.format(config.namespace))
+        # We don't want to let people try to create Articles here, as
+        # they'll just 404 on arrival because the apphook isn't active.
+        if is_valid_namespace(config.namespace):
             published_configs.append(config)
-        except NoReverseMatch:
-            # We don't want to let people try to create Articles here, as
-            # they'll just 404 on arrival because the apphook isn't active.
-            pass
     return published_configs
 
 

--- a/aldryn_newsblog/tests/__init__.py
+++ b/aldryn_newsblog/tests/__init__.py
@@ -5,16 +5,23 @@ from __future__ import unicode_literals
 import os
 import random
 import string
+import sys
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.urlresolvers import clear_url_caches
+from django.core.cache import cache
 from django.utils.timezone import now
 from django.utils.translation import override
 from aldryn_categories.models import Category
+from aldryn_newsblog.cms_app import NewsBlogApp
 from aldryn_newsblog.models import Article, NewsBlogConfig
 from aldryn_people.models import Person
 from aldryn_search.helpers import get_request
 from cms import api
+from cms.apphook_pool import apphook_pool
+from cms.appresolver import clear_app_resolvers
+from cms.exceptions import AppAlreadyRegistered
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
 from cms.utils import get_cms_setting
 from parler.utils.context import switch_language
@@ -181,9 +188,110 @@ class NewsBlogTestsMixin(object):
                 page.publish(language)
 
 
-class NewsBlogTestCase(NewsBlogTestsMixin, CMSTestCase):
+class CleanUpMixin(object):
+    apphook_object = None
+
+    def tearDown(self):
+        """
+        Do a proper cleanup, delete everything what is preventing us from
+        clean environment for tests.
+        :return: None
+        """
+        self.app_config.delete()
+        self.reset_all()
+        cache.clear()
+        super(CleanUpMixin, self).tearDown()
+
+    def get_apphook_object(self):
+        return self.apphook_object
+
+    def reset_apphook_cmsapp(self, apphook_object=None):
+        """
+        For tests that should not be polluted by previous setup we need to
+        ensure that app hooks are reloaded properly. One of the steps is to
+        reset the relation between EventListAppHook and EventsConfig
+        """
+        if apphook_object is None:
+            apphook_object = self.get_apphook_object()
+        app_config = getattr(apphook_object, 'app_config', None)
+        if (app_config and
+                getattr(app_config, 'cmsapp', None)):
+            delattr(apphook_object.app_config, 'cmsapp')
+        if getattr(app_config, 'cmsapp', None):
+            delattr(app_config, 'cmsapp')
+
+    def reset_all(self):
+        """
+        Reset all that could leak from previous test to current/next test.
+        :return: None
+        """
+        apphook_object = self.get_apphook_object()
+        self.delete_app_module(apphook_object.__module__)
+        self.reload_urls(apphook_object)
+        self.apphook_clear()
+
+    def delete_app_module(self, app_module=None):
+        """
+        Remove APP_MODULE from sys.modules. Taken from cms.
+        :return: None
+        """
+        if app_module is None:
+            apphook_object = self.get_apphook_object()
+            app_module = apphook_object.__module__
+        if app_module in sys.modules:
+            del sys.modules[app_module]
+
+    def apphook_clear(self):
+        """
+        Clean up apphook_pool and sys.modules. Taken from cms with slight
+        adjustments and fixes.
+        :return: None
+        """
+        try:
+            apphooks = apphook_pool.get_apphooks()
+        except AppAlreadyRegistered:
+            # there is an issue with discover apps, or i'm using it wrong.
+            # setting discovered to True solves it. Maybe that is due to import
+            # from aldryn_events.cms_app which registers EventListAppHook
+            apphook_pool.discovered = True
+            apphooks = apphook_pool.get_apphooks()
+
+        for name, label in list(apphooks):
+            if apphook_pool.apps[name].__class__.__module__ in sys.modules:
+                del sys.modules[apphook_pool.apps[name].__class__.__module__]
+        apphook_pool.clear()
+        self.reset_apphook_cmsapp()
+
+    def reload_urls(self, apphook_object=None):
+        """
+        Clean up url related things (caches, app resolvers, modules).
+        Taken from cms.
+        :return: None
+        """
+        if apphook_object is None:
+            apphook_object = self.get_apphook_object()
+        app_module = apphook_object.__module__
+        package = app_module.split('.')[0]
+        clear_app_resolvers()
+        clear_url_caches()
+        url_modules = [
+            'cms.urls',
+            '{0}.urls'.format(package),
+            settings.ROOT_URLCONF
+        ]
+
+        for module in url_modules:
+            if module in sys.modules:
+                del sys.modules[module]
+
+
+class NewsBlogTestCase(CleanUpMixin, NewsBlogTestsMixin, CMSTestCase):
+    apphook_object = NewsBlogApp
     pass
 
 
-class NewsBlogTransactionTestCase(NewsBlogTestsMixin, TransactionCMSTestCase):
+class NewsBlogTransactionTestCase(CleanUpMixin,
+                                  NewsBlogTestsMixin,
+                                  TransactionCMSTestCase):
+    apphook_object = NewsBlogApp
     pass

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -16,7 +16,7 @@ from django.utils.translation import override
 
 from aldryn_newsblog.models import Article, NewsBlogConfig
 from aldryn_newsblog.search_indexes import ArticleIndex
-from cms.utils.i18n import get_current_language
+from cms.utils.i18n import get_current_language, force_language
 from easy_thumbnails.files import get_thumbnailer
 from filer.models.imagemodels import Image
 from parler.tests.utils import override_parler_settings
@@ -530,3 +530,212 @@ class TestIndex(NewsBlogTestCase):
                         self.index.get_title(article_de), 'de title')
                     self.assertEqual(
                         self.index.get_description(article_de), 'de lead in')
+
+
+class ViewLanguageFallbackMixin(object):
+    view_name = None
+    view_kwargs = {}
+
+    def get_view_kwargs(self):
+        """
+        Prepare and return kwargs to resolve view
+        :return: dict
+        """
+        return {}.update(self.view_kwargs)
+
+    def create_authors(self):
+        self.author = self.create_person()
+        self.owner = self.author.user
+        return self.author, self.owner
+
+    def create_de_article(self, author=None, owner=None, app_config=None,
+                          categories=None):
+        if author is None:
+            author = self.author
+        if owner is None:
+            owner = self.owner
+        if app_config is None:
+            app_config = self.app_config
+
+        with force_language('de'):
+            de_article = Article.objects.create(
+                title='a DE title',
+                slug='a-de-title',
+                lead_in='DE lead in text',
+                author=author,
+                owner=owner,
+                app_config=app_config,
+                publishing_date=now(),
+                is_published=True)
+        if categories:
+            de_article.categories = categories
+        de_article.tags.add('tag1')
+        de_article.save()
+        return de_article
+
+    def create_en_articles(self, author=None, owner=None, app_config=None,
+                           amount=3, categories=None):
+        if author is None:
+            author = self.author
+        if owner is None:
+            owner = self.owner
+        if app_config is None:
+            app_config = self.app_config
+
+        with force_language('en'):
+            articles = []
+            for _ in range(amount):
+                article = self.create_article(author=author,
+                                              owner=owner,
+                                              app_config=app_config)
+                if categories:
+                    article.categories = categories
+                article.tags.add('tag1')
+                article.save()
+                articles.append(article)
+        return articles
+
+    def test_a0_en_only(self):
+        namespace = self.app_config.namespace
+        self.page.unpublish('de')
+        author, owner = self.create_authors()
+        author.translations.create(
+            slug='{0}-de'.format(author.slug),
+            language_code='de')
+        de_article = self.create_de_article(
+            author=author,
+            owner=owner,
+            categories=[self.category1],
+        )
+        articles = self.create_en_articles(categories=[self.category1])
+        with force_language('en'):
+            response = self.client.get(
+                reverse(
+                    '{0}:{1}'.format(namespace, self.view_name),
+                    kwargs=self.get_view_kwargs()
+                )
+            )
+        for article in articles:
+            self.assertContains(response, article.title)
+        self.assertNotContains(response, de_article.title)
+
+    def test_a1_en_de(self):
+        namespace = self.app_config.namespace
+        author, owner = self.create_authors()
+        author.translations.create(
+            slug='{0}-de'.format(author.slug),
+            language_code='de')
+        de_article = self.create_de_article(
+            author=author,
+            owner=owner,
+            categories=[self.category1]
+        )
+        articles = self.create_en_articles(categories=[self.category1])
+        with force_language('en'):
+            response = self.client.get(
+                reverse(
+                    '{0}:{1}'.format(namespace, self.view_name),
+                    kwargs=self.get_view_kwargs()
+                )
+            )
+        for article in articles:
+            self.assertContains(response, article.title)
+        self.assertContains(response, de_article.title)
+
+
+class ArticleListViewLanguageFallback(ViewLanguageFallbackMixin,
+                                      NewsBlogTestCase):
+    view_name = 'article-list'
+
+
+class LatestArticlesFeedLanguageFallback(ViewLanguageFallbackMixin,
+                                         NewsBlogTestCase):
+    view_name = 'article-list-feed'
+
+
+class YearArticleListLanguageFallback(ViewLanguageFallbackMixin,
+                                      NewsBlogTestCase):
+    view_name = 'article-list-by-year'
+
+    def get_view_kwargs(self):
+        return {'year': now().year}
+
+
+class MonthArticleListLanguageFallback(ViewLanguageFallbackMixin,
+                                       NewsBlogTestCase):
+    view_name = 'article-list-by-month'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'year': now().year,
+            'month': now().month,
+        }
+        return kwargs
+
+
+class DayArticleListLanguageFallback(ViewLanguageFallbackMixin,
+                                     NewsBlogTestCase):
+    view_name = 'article-list-by-day'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'year': now().year,
+            'month': now().month,
+            'day': now().day,
+        }
+        return kwargs
+
+
+class AuthorArticleListLanguageFallback(ViewLanguageFallbackMixin,
+                                        NewsBlogTestCase):
+    view_name = 'article-list-by-author'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'author': self.author.slug
+        }
+        return kwargs
+
+
+class CategoryArticleListLanguageFallback(ViewLanguageFallbackMixin,
+                                          NewsBlogTestCase):
+    view_name = 'article-list-by-category'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'category': self.category1.slug
+        }
+        return kwargs
+
+
+class CategoryFeedListLanguageFallback(ViewLanguageFallbackMixin,
+                                       NewsBlogTestCase):
+    view_name = 'article-list-by-category-feed'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'category': self.category1.slug
+        }
+        return kwargs
+
+
+class TagArticleListLanguageFallback(ViewLanguageFallbackMixin,
+                                     NewsBlogTestCase):
+    view_name = 'article-list-by-tag'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'tag': 'tag1'
+        }
+        return kwargs
+
+
+class TagFeedLanguageFallback(ViewLanguageFallbackMixin,
+                              NewsBlogTestCase):
+    view_name = 'article-list-by-tag-feed'
+
+    def get_view_kwargs(self):
+        kwargs = {
+            'tag': 'tag1'
+        }
+        return kwargs

--- a/aldryn_newsblog/utils/utilities.py
+++ b/aldryn_newsblog/utils/utilities.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.db import models
 from django.template import RequestContext
@@ -14,6 +15,8 @@ except ImportError:
     from django.utils.encoding import force_text as force_unicode
 from django.utils.html import strip_tags as _strip_tags
 from django.utils.text import smart_split
+
+from cms.utils.i18n import force_language, get_language_object
 
 from lxml.html.clean import Cleaner as LxmlCleaner
 
@@ -148,3 +151,38 @@ def add_prefix_to_path(path, prefix):
         return "{0}/{1}".format(prefix, splitted_path[0])
     # directory/template.html => directory/prefix/template.html
     return "{0}/{1}/{2}".format(splitted_path[0], prefix, splitted_path[1])
+
+
+def is_valid_namespace(namespace):
+    """
+    Check if provided namespace has an app-hooked page.
+    Returns True or False.
+    """
+    try:
+        reverse('{0}:article-list'.format(namespace))
+    except (NoReverseMatch, AttributeError):
+        return False
+    return True
+
+
+def is_valid_namespace_for_language(namespace, language_code):
+    """
+    Check if provided namespace has an app-hooked page for given language_code.
+    Returns True or False.
+    """
+    with force_language(language_code):
+        return is_valid_namespace(namespace)
+
+
+def get_valid_languages(namespace, language_code, site_id=None):
+        langs = [language_code]
+        if site_id is None:
+            site_id = getattr(Site.objects.get_current(), 'pk', None)
+        current_language = get_language_object(language_code, site_id)
+        fallbacks = current_language.get('fallbacks', None)
+        if fallbacks:
+            langs += list(fallbacks)
+        valid_translations = [
+            lang_code for lang_code in langs
+            if is_valid_namespace_for_language(namespace, lang_code)]
+        return valid_translations

--- a/aldryn_newsblog/utils/utilities.py
+++ b/aldryn_newsblog/utils/utilities.py
@@ -160,7 +160,7 @@ def is_valid_namespace(namespace):
     """
     try:
         reverse('{0}:article-list'.format(namespace))
-    except (NoReverseMatch, AttributeError):
+    except NoReverseMatch:
         return False
     return True
 
@@ -175,14 +175,14 @@ def is_valid_namespace_for_language(namespace, language_code):
 
 
 def get_valid_languages(namespace, language_code, site_id=None):
-        langs = [language_code]
-        if site_id is None:
-            site_id = getattr(Site.objects.get_current(), 'pk', None)
-        current_language = get_language_object(language_code, site_id)
-        fallbacks = current_language.get('fallbacks', None)
-        if fallbacks:
-            langs += list(fallbacks)
-        valid_translations = [
-            lang_code for lang_code in langs
-            if is_valid_namespace_for_language(namespace, lang_code)]
-        return valid_translations
+    langs = [language_code]
+    if site_id is None:
+        site_id = getattr(Site.objects.get_current(), 'pk', None)
+    current_language = get_language_object(language_code, site_id)
+    fallbacks = current_language.get('fallbacks', None)
+    if fallbacks:
+        langs += list(fallbacks)
+    valid_translations = [
+        lang_code for lang_code in langs
+        if is_valid_namespace_for_language(namespace, lang_code)]
+    return valid_translations

--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -92,13 +92,16 @@ class AppHookCheckMixin(object):
 
     def get_queryset(self):
         # filter available objects to contain only resolvable for current
-        # language
+        # language. IMPORTANT: after .translated - we cannot use .filter
+        # on translated fields (parler/django limitation).
+        # if your mixin contains filtering after super call - please place it
+        # after this mixin.
         qs = super(AppHookCheckMixin, self).get_queryset()
         return qs.translated(*self.valid_languages)
 
 
-class ArticleDetail(PreviewModeMixin, TranslatableSlugMixin, AppConfigMixin,
-                    AppHookCheckMixin, TemplatePrefixMixin, DetailView):
+class ArticleDetail(AppConfigMixin, AppHookCheckMixin, PreviewModeMixin,
+                    TranslatableSlugMixin, TemplatePrefixMixin, DetailView):
     model = Article
     slug_field = 'slug'
     year_url_kwarg = 'year'
@@ -190,9 +193,8 @@ class ArticleDetail(PreviewModeMixin, TranslatableSlugMixin, AppConfigMixin,
             return None
 
 
-class ArticleListBase(
-        TemplatePrefixMixin, PreviewModeMixin,
-        ViewUrlMixin, AppConfigMixin, AppHookCheckMixin, ListView):
+class ArticleListBase(AppConfigMixin, AppHookCheckMixin, TemplatePrefixMixin,
+                      PreviewModeMixin, ViewUrlMixin, ListView):
     model = Article
     show_header = False
 

--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -5,6 +5,11 @@ from __future__ import unicode_literals
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 
+try:
+    from django.contrib.sites.shortcuts import get_current_site
+except ImportError:
+    # Django 1.6
+    from django.contrib.sites.models import get_current_site
 from django.db.models import Q
 from django.http import (
     Http404,
@@ -24,6 +29,7 @@ from aldryn_apphooks_config.mixins import AppConfigMixin
 from aldryn_categories.models import Category
 from aldryn_people.models import Person
 
+from aldryn_newsblog.utils.utilities import get_valid_languages
 from .models import Article
 from .utils import add_prefix_to_path
 
@@ -71,8 +77,28 @@ class PreviewModeMixin(EditModeMixin):
         return qs
 
 
+class AppHookCheckMixin(object):
+
+    def dispatch(self, request, *args, **kwargs):
+        language = translation.get_language_from_request(
+            request, check_path=True)
+        site_id = getattr(get_current_site(request), 'id', None)
+        self.valid_languages = get_valid_languages(
+            self.namespace,
+            language_code=language,
+            site_id=site_id)
+        return super(AppHookCheckMixin, self).dispatch(
+            request, *args, **kwargs)
+
+    def get_queryset(self):
+        # filter available objects to contain only resolvable for current
+        # language
+        qs = super(AppHookCheckMixin, self).get_queryset()
+        return qs.translated(*self.valid_languages)
+
+
 class ArticleDetail(PreviewModeMixin, TranslatableSlugMixin, AppConfigMixin,
-                    TemplatePrefixMixin, DetailView):
+                    AppHookCheckMixin, TemplatePrefixMixin, DetailView):
     model = Article
     slug_field = 'slug'
     year_url_kwarg = 'year'
@@ -166,7 +192,7 @@ class ArticleDetail(PreviewModeMixin, TranslatableSlugMixin, AppConfigMixin,
 
 class ArticleListBase(
         TemplatePrefixMixin, PreviewModeMixin,
-        ViewUrlMixin, AppConfigMixin, ListView):
+        ViewUrlMixin, AppConfigMixin, AppHookCheckMixin, ListView):
     model = Article
     show_header = False
 

--- a/test
+++ b/test
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-djangocms-helper aldryn_newsblog --cms test --extra-settings=test_settings $@
+djangocms-helper aldryn_newsblog --cms test --boilerplate --extra-settings=test_settings $@

--- a/test_settings.py
+++ b/test_settings.py
@@ -38,14 +38,22 @@ HELPER_SETTINGS = {
     'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     # app-specific
     'PARLER_LANGUAGES': {
-        1: (
-            {'code': 'de', },
-            {'code': 'fr', },
-            {'code': 'en', },
-        ),
+        1: [
+            {
+                'code': u'en',
+                'fallbacks': [u'de'],
+                'hide_untranslated': False
+            },
+            {
+                'code': u'de',
+                'fallbacks': [u'en'],
+                'hide_untranslated': False
+            }
+        ],
         'default': {
-            'hide_untranslated': True,  # PLEASE DO NOT CHANGE THIS
-        }
+            'code': u'en',
+            'fallbacks': [u'en'],
+            'hide_untranslated': False}
     },
     'SITE_ID': 1,
     'CMS_LANGUAGES': {


### PR DESCRIPTION
PR introduces:
* views test cases for fallbacks
* changes in views
* test_settings changes
* few utility methods

If ``CMS_LANGUAGES`` and ``PARLER_LANGUAGES`` configured to provide fallbacks, newsblog views should respect those settings and filter accordingly (which usually they do) but in other hand if there is no application hook for one of the languages - we will/can get 500 error. This PR introduces changes to render objects only if they are accessible (with respect to fallback settings).
