### PR TITLE
Uses a rich-text editor for the Content field in the wizard

### DIFF
--- a/aldryn_newsblog/cms_wizards.py
+++ b/aldryn_newsblog/cms_wizards.py
@@ -12,6 +12,7 @@ from cms.wizards.wizard_pool import wizard_pool
 from cms.wizards.wizard_base import Wizard
 from cms.wizards.forms import BaseFormMixin
 
+from djangocms_text_ckeditor.widgets import TextEditorWidget
 from parler.forms import TranslatableModelForm
 
 from .cms_appconfig import NewsBlogConfig
@@ -64,9 +65,9 @@ class CreateNewsBlogArticleForm(BaseFormMixin, TranslatableModelForm):
     """
 
     content = forms.CharField(
-        label="Content", help_text=_("Optional. If provided, will be added to "
-                                     "the main body of the article."),
-        required=False, widget=forms.Textarea())
+        label="Content", required=False, widget=TextEditorWidget,
+        help_text=_("Optional. If provided, will be added to the main body of "
+                    "the article."))
 
     class Meta:
         model = Article

--- a/aldryn_newsblog/cms_wizards.py
+++ b/aldryn_newsblog/cms_wizards.py
@@ -13,6 +13,7 @@ from cms.wizards.wizard_base import Wizard
 from cms.wizards.forms import BaseFormMixin
 
 from djangocms_text_ckeditor.widgets import TextEditorWidget
+from djangocms_text_ckeditor.html import clean_html
 from parler.forms import TranslatableModelForm
 
 from .cms_appconfig import NewsBlogConfig
@@ -91,7 +92,7 @@ class CreateNewsBlogArticleForm(BaseFormMixin, TranslatableModelForm):
 
         # If 'content' field has value, create a TextPlugin with same and add
         # it to the PlaceholderField
-        content = self.cleaned_data.get('content', '')
+        content = clean_html(self.cleaned_data.get('content', ''), False)
         if content and permissions.has_plugin_permission(
                 self.user, 'TextPlugin', 'add'):
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ REQUIREMENTS = [
     'backport_collections==0.1',
     'django-appdata>=0.1.4',
     'django-cms>=3.0.12',
+    'djangocms-text-ckeditor',
     'django-filer>=0.9.9',
     'django-parler>=1.4',
     'django-reversion>=1.8.2,<1.9',


### PR DESCRIPTION
Note, the additional requirement of `djangocms-text-ckeditor` should have always been there.