### PR TITLE
Fix tests for new parler

### DIFF
--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -35,6 +35,7 @@ PARLER_LANGUAGES_HIDE = {
     ),
     'default': {
         'hide_untranslated': True,
+        'fallbacks': []
     }
 }
 
@@ -46,6 +47,7 @@ PARLER_LANGUAGES_SHOW = {
     ),
     'default': {
         'hide_untranslated': False,
+        'fallbacks': []
     }
 }
 


### PR DESCRIPTION
Looks like there's a small bug in Parler 1.6 where if you don't explicitly set the fallbacks, it will set fallbacks='en' where 'en' is settings.LANGUAGE_CODE. Because fallbacks is now a list, there is code in 1.6 that is expecting a list and fallbacks=u'en' breaks things within Parler.

I've submitted a PR to Parler too: https://github.com/edoburu/django-parler/pull/113

Fix for now is just to explicitly set no fallbacks in our test config by setting fallbacks = [].