### PR TITLE
Fixes app_config drop-menu

### DIFF
--- a/aldryn_newsblog/cms_wizards.py
+++ b/aldryn_newsblog/cms_wizards.py
@@ -70,6 +70,8 @@ class CreateNewsBlogArticleForm(BaseFormMixin, TranslatableModelForm):
     class Meta:
         model = Article
         fields = ['title', 'app_config', 'is_published', 'lead_in', 'content', ]
+        # The natural widget for app_config is meant for normal Admin views and
+        # contains JS to refresh the page on change. This is not wanted here.
         widgets = {'app_config': forms.Select()}
 
     def __init__(self, **kwargs):

--- a/aldryn_newsblog/cms_wizards.py
+++ b/aldryn_newsblog/cms_wizards.py
@@ -70,6 +70,7 @@ class CreateNewsBlogArticleForm(BaseFormMixin, TranslatableModelForm):
     class Meta:
         model = Article
         fields = ['title', 'app_config', 'is_published', 'lead_in', 'content', ]
+        widgets = {'app_config': forms.Select()}
 
     def __init__(self, **kwargs):
         super(CreateNewsBlogArticleForm, self).__init__(**kwargs)


### PR DESCRIPTION
The natural widget for an app_config field will refresh the page via JS. We shouldn't/needn't do this in a wizard.