### PR TITLE
Fix integration tests for 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     # NOTE: FE-TESTS ARE DISABLED UNTIL THEY ARE FIXED FOR CMS 3.2
     # NOTE: MYSQL AND POSTGRES TESTS ARE DISABLED UNTIL #339 IS MERGED.
     - TOXENV=flake8
-    - TOXENV=py34-dj18-sqlite-cms32
+    - TOXENV=py34-dj18-sqlite-cms32-fe
 #    - TOXENV=py34-dj18-mysql-cms32
 #    - TOXENV=py34-dj18-postgres-cms32
     - TOXENV=py34-dj18-sqlite-cms31
@@ -33,7 +33,7 @@ env:
 #    - TOXENV=py34-dj17-postgres-cms32
     - TOXENV=py34-dj17-sqlite-cms31
     - TOXENV=py34-dj17-sqlite-cms30
-    - TOXENV=py27-dj17-sqlite-cms32
+    - TOXENV=py27-dj17-sqlite-cms32-fe
 #    - TOXENV=py27-dj17-mysql-cms32
 #    - TOXENV=py27-dj17-postgres-cms32
     - TOXENV=py27-dj17-sqlite-cms31
@@ -41,7 +41,7 @@ env:
     - TOXENV=py27-dj16-sqlite-cms32
     - TOXENV=py27-dj16-sqlite-cms31
     - TOXENV=py27-dj16-sqlite-cms30
-    - TOXENV=py26-dj16-sqlite-cms32
+    - TOXENV=py26-dj16-sqlite-cms32-fe
 #    - TOXENV=py26-dj16-oldmysql-cms32
 #    - TOXENV=py26-dj16-postgres-cms32
     - TOXENV=py26-dj16-sqlite-cms31

--- a/aldryn_newsblog/tests/frontend/integration/pages/page.newsblog.crud.js
+++ b/aldryn_newsblog/tests/frontend/integration/pages/page.newsblog.crud.js
@@ -4,38 +4,39 @@
  */
 
 'use strict';
-/* global by, element, expect */
+/* global browser, by, element, expect */
 
 // #############################################################################
 // INTEGRATION TEST PAGE OBJECT
 
-var cmsProtractorHelper = require('cms-protractor-helper');
-
-var newsBlogPage = {
+var page = {
     site: 'http://127.0.0.1:8000/en/',
 
     // log in, log out
     editModeLink: element(by.css('.inner a[href="/?edit"]')),
-    usernameInput: element(by.id('id_cms-username')),
-    passwordInput: element(by.id('id_cms-password')),
-    loginButton: element(by.css('.cms_form-login input[type="submit"]')),
-    userMenus: element.all(by.css('.cms_toolbar-item-navigation > li > a')),
-    testLink: element(by.css('.selected a')),
+    usernameInput: element(by.id('id_username')),
+    passwordInput: element(by.id('id_password')),
+    loginButton: element(by.css('input[type="submit"]')),
+    userMenus: element.all(by.css('.cms-toolbar-item-navigation > li > a')),
 
     // adding new page
+    modalCloseButton: element(by.css('.cms-modal-close')),
     userMenuDropdown: element(by.css(
-        '.cms_toolbar-item-navigation-hover')),
+        '.cms-toolbar-item-navigation-hover')),
     administrationOptions: element.all(by.css(
-        '.cms_toolbar-item-navigation a[href="/en/admin/"]')),
-    sideMenuIframe: element(by.css('.cms_sideframe-frame iframe')),
+        '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
+    sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
     addPageLink: element(by.css('.sitemap-noentry .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col1 [href*="preview/"]')),
+    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    testLink: element(by.cssContainingText('a', 'Test')),
+    sideFrameClose: element(by.css('.cms-sideframe-close')),
 
     // adding new apphook config
+    breadcrumbs: element(by.css('.breadcrumbs')),
     breadcrumbsLinks: element.all(by.css('.breadcrumbs a')),
     newsBlogConfigsLink: element(by.css('.model-newsblogconfig > th > a')),
     editConfigsLink: element(by.css('.row1 > th > a')),
@@ -46,20 +47,22 @@ var newsBlogPage = {
 
     // adding new article
     addArticleButton: element(by.css('.model-article .addlink')),
+    editArticlesLink: element(by.css('.model-article .changelink')),
     englishLanguageTab: element(by.css(
         '.parler-language-tabs > .empty > a[href*="language=en"]')),
     saveAndContinueButton: element(by.css('.submit-row [name="_continue"]')),
+    editArticleLinksTable: element(by.css('.results')),
     editArticleLinks: element.all(by.css(
         '.results th > [href*="/aldryn_newsblog/article/"]')),
 
     // adding article to the page
     aldrynNewsBlogBlock: element(by.css('.aldryn-newsblog-list')),
     advancedSettingsOption: element(by.css(
-        '.cms_toolbar-item-navigation [href*="advanced-settings"]')),
-    modalIframe: element(by.css('.cms_modal-frame iframe')),
+        '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
+    modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     newsBlogOption: element(by.css('option[value="NewsBlogApp"]')),
-    saveModalButton: element(by.css('.cms_modal-buttons .cms_btn-action')),
+    saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
     newsBlogMetaBlock: element(by.css('.aldryn-newsblog-meta')),
     articleLink: element(by.css('.aldryn-newsblog-list h2 > a')),
 
@@ -73,26 +76,34 @@ var newsBlogPage = {
         credentials = credentials ||
             { username: 'admin', password: 'admin' };
 
-        newsBlogPage.usernameInput.clear();
+        page.usernameInput.clear();
 
         // fill in email field
-        return newsBlogPage.usernameInput.sendKeys(credentials.username)
-            .then(function () {
-            newsBlogPage.passwordInput.clear();
+        page.usernameInput.sendKeys(
+            credentials.username).then(function () {
+            page.passwordInput.clear();
 
             // fill in password field
-            return newsBlogPage.passwordInput.sendKeys(credentials.password);
+            return page.passwordInput.sendKeys(
+                credentials.password);
         }).then(function () {
-            newsBlogPage.loginButton.click();
+            return page.loginButton.click();
+        }).then(function () {
+            // this is required for django1.6, because it doesn't redirect
+            // correctly from admin
+            browser.get(page.site);
 
             // wait for user menu to appear
-            cmsProtractorHelper.waitFor(newsBlogPage.userMenus.first());
+            browser.wait(browser.isElementPresent(
+                page.userMenus.first()),
+                page.mainElementsWaitTime);
 
             // validate user menu
-            expect(newsBlogPage.userMenus.first().isDisplayed()).toBeTruthy();
+            expect(page.userMenus.first().isDisplayed())
+                .toBeTruthy();
         });
     }
 
 };
 
-module.exports = newsBlogPage;
+module.exports = page;

--- a/aldryn_newsblog/tests/frontend/integration/specs/spec.newsblog.crud.js
+++ b/aldryn_newsblog/tests/frontend/integration/specs/spec.newsblog.crud.js
@@ -20,17 +20,13 @@ describe('Aldryn Newsblog tests: ', function () {
         browser.get(newsBlogPage.site);
 
         // check if the page already exists
-        return newsBlogPage.testLink.isPresent().then(function (present) {
+        newsBlogPage.testLink.isPresent().then(function (present) {
             if (present === true) {
                 // go to the main page
                 browser.get(newsBlogPage.site + '?edit');
-            } else {
-                // click edit mode link
-                newsBlogPage.editModeLink.click();
+                browser.sleep(1000);
+                cmsProtractorHelper.waitForDisplayed(newsBlogPage.usernameInput);
             }
-
-            // wait for username input to appear
-            cmsProtractorHelper.waitFor(newsBlogPage.usernameInput);
 
             // login to the site
             newsBlogPage.cmsLogin();
@@ -38,6 +34,17 @@ describe('Aldryn Newsblog tests: ', function () {
     });
 
     it('creates a new test page', function () {
+        // close the wizard if necessary
+        newsBlogPage.modalCloseButton.isDisplayed().then(function (displayed) {
+            if (displayed) {
+                newsBlogPage.modalCloseButton.click();
+            }
+        });
+
+        cmsProtractorHelper.waitForDisplayed(newsBlogPage.userMenus.first());
+        // have to wait till animation finished
+        browser.sleep(300);
+
         // click the example.com link in the top menu
         return newsBlogPage.userMenus.first().click().then(function () {
             // wait for top menu dropdown options to appear
@@ -50,7 +57,7 @@ describe('Aldryn Newsblog tests: ', function () {
 
             // switch to sidebar menu iframe
             browser.switchTo().frame(browser.findElement(
-                By.css('.cms_sideframe-frame iframe')));
+                By.css('.cms-sideframe-frame iframe')));
 
             cmsProtractorHelper.waitFor(newsBlogPage.pagesLink);
 
@@ -108,13 +115,18 @@ describe('Aldryn Newsblog tests: ', function () {
 
                 // switch to sidebar menu iframe
                 return browser.switchTo().frame(browser.findElement(By.css(
-                    '.cms_sideframe-frame iframe')));
+                    '.cms-sideframe-frame iframe')));
             }
         }).then(function () {
-            cmsProtractorHelper.waitFor(newsBlogPage.breadcrumbsLinks.first());
+            browser.sleep(1000);
 
-            // click the Home link in breadcrumbs
-            newsBlogPage.breadcrumbsLinks.first().click();
+            newsBlogPage.breadcrumbs.isPresent().then(function (present) {
+                if (present) {
+                    // click the Home link in breadcrumbs
+                    cmsProtractorHelper.waitFor(newsBlogPage.breadcrumbsLinks.first());
+                    newsBlogPage.breadcrumbsLinks.first().click();
+                }
+            });
 
             cmsProtractorHelper.waitFor(newsBlogPage.newsBlogConfigsLink);
 
@@ -153,13 +165,9 @@ describe('Aldryn Newsblog tests: ', function () {
 
         newsBlogPage.addArticleButton.click();
 
-        cmsProtractorHelper.waitFor(newsBlogPage.englishLanguageTab);
+        cmsProtractorHelper.waitFor(newsBlogPage.titleInput);
 
-        return newsBlogPage.englishLanguageTab.click().then(function () {
-            cmsProtractorHelper.waitFor(newsBlogPage.titleInput);
-
-            return newsBlogPage.titleInput.sendKeys(articleName);
-        }).then(function () {
+        newsBlogPage.titleInput.sendKeys(articleName).then(function () {
             browser.actions().mouseMove(newsBlogPage.saveAndContinueButton)
                 .perform();
             newsBlogPage.saveButton.click();
@@ -194,7 +202,7 @@ describe('Aldryn Newsblog tests: ', function () {
 
                     // switch to modal iframe
                     browser.switchTo().frame(browser.findElement(By.css(
-                        '.cms_modal-frame iframe')));
+                        '.cms-modal-frame iframe')));
 
                     cmsProtractorHelper.selectOption(newsBlogPage.applicationSelect,
                         'NewsBlog', newsBlogPage.newsBlogOption);
@@ -226,18 +234,32 @@ describe('Aldryn Newsblog tests: ', function () {
     });
 
     it('deletes article', function () {
-        // wait for modal iframe to appear
-        cmsProtractorHelper.waitFor(newsBlogPage.sideMenuIframe);
+        // have to wait till animation finished
+        browser.sleep(300);
+        // click the example.com link in the top menu
+        newsBlogPage.userMenus.first().click().then(function () {
+            // wait for top menu dropdown options to appear
+            cmsProtractorHelper.waitForDisplayed(newsBlogPage.userMenuDropdown);
+
+            return newsBlogPage.administrationOptions.first().click();
+        }).then(function () {
+            // wait for modal iframe to appear
+            cmsProtractorHelper.waitFor(newsBlogPage.sideMenuIframe);
+        });
 
         // switch to sidebar menu iframe
         browser.switchTo()
-            .frame(browser.findElement(By.css('.cms_sideframe-frame iframe')));
+            .frame(browser.findElement(By.css('.cms-sideframe-frame iframe')));
 
-        // wait for edit event link to appear
-        cmsProtractorHelper.waitFor(newsBlogPage.editArticleLinks.first());
-
-        // validate edit article links texts to delete proper article
-        return newsBlogPage.editArticleLinks.first().getText().then(function (text) {
+        cmsProtractorHelper.waitFor(newsBlogPage.editArticlesLink);
+        browser.sleep(100);
+        newsBlogPage.editArticlesLink.click().then(function () {
+            // wait for edit event link to appear
+            return cmsProtractorHelper.waitFor(newsBlogPage.editArticleLinksTable);
+        }).then(function () {
+            // validate edit article links texts to delete proper article
+            return newsBlogPage.editArticleLinks.first().getText();
+        }).then(function (text) {
             if (text === articleName) {
                 return newsBlogPage.editArticleLinks.first().click();
             } else {

--- a/aldryn_newsblog/tests/frontend/protractor.conf.js
+++ b/aldryn_newsblog/tests/frontend/protractor.conf.js
@@ -20,8 +20,7 @@ var config = {
 
     // Capabilities to be passed to the webdriver instance
     capabilities: {
-        'browserName': 'phantomjs',
-        'phantomjs.binary.path': require('phantomjs').path
+        'browserName': 'chrome'
     },
 
     onPrepare: function () {
@@ -36,7 +35,8 @@ var config = {
 
     jasmineNodeOpts: {
         showColors: true,
-        defaultTimeoutInterval: 240000
+        defaultTimeoutInterval: 240000,
+        realtimeFailure: true
     }
 
 };

--- a/test_settings.py
+++ b/test_settings.py
@@ -35,6 +35,7 @@ HELPER_SETTINGS = {
     ),
     'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES': [('dummy', 'dummy'), ],
     'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
+    'CMS_PERMISSION': True,
     'SITE_ID': 1,
     'LANGUAGES': (
         ('en', 'English'),


### PR DESCRIPTION
- changes tests so they work with 3.2
    - sideframe is now covering most of the view so it has to be opened/closed
    - admin behaviour changed slightly
    - selectors changed
    - added additional safety waits
- change the default local runner from phantomjs to chrome because literally nothing works in phantom (and http://www.protractortest.org/#/browser-support)
- add CMS_PERMISSION setting, because apparently there is a bug in the 3.2 that hides the Pages menu item if it's not set