### PR TITLE
Add default templates to package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+1.1.0 (UNRELEASED)
+-------------------
+
+* Add stripped default django templates to `/aldryn_newsblog/templates`
+
 1.0.12 (2016-01-12)
 -------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include aldryn_newsblog/boilerplates *
+recursive-include aldryn_newsblog/templates *

--- a/aldryn_newsblog/templates/aldryn_newsblog/article_detail.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/article_detail.html
@@ -1,0 +1,20 @@
+{% extends "aldryn_newsblog/base.html" %}
+{% load i18n apphooks_config_tags %}
+
+{% block title %}
+    {{ article.title }} - {{ block.super }}
+{% endblock %}
+
+{% block newsblog_content %}
+    {% include "aldryn_newsblog/includes/article.html" with detail_view="true" %}
+
+    <ul>
+        {% if prev_article %}
+            <li><a href="{{ prev_article.get_absolute_url }}">{% trans "Previous Article" %}</a></li>
+        {% endif %}
+        <li><a href="{% namespace_url "article-list" %}">{% trans "Back to Overview" %}</a></li>
+        {% if next_article %}
+            <li><a href="{{ next_article.get_absolute_url }}">{% trans "Next Article" %}</a></li>
+        {% endif %}
+    </ul>
+{% endblock %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/article_list.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/article_list.html
@@ -1,0 +1,12 @@
+{% extends "aldryn_newsblog/base.html" %}
+{% load i18n %}
+
+{% block newsblog_content %}
+    {% for article in article_list %}
+        {% include "aldryn_newsblog/includes/article.html" %}
+    {% empty %}
+        <p>{% trans "No items available" %}</p>
+    {% endfor %}
+
+    {% include "aldryn_newsblog/includes/pagination.html" %}
+{% endblock %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/base.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/base.html
@@ -1,0 +1,7 @@
+{% extends CMS_TEMPLATE %}
+
+{% block content %}
+    {% block newsblog_content %}
+        {# article_list.html and article_detail.html extend this template #}
+    {% endblock %}
+{% endblock content %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/includes/article.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/includes/article.html
@@ -1,0 +1,48 @@
+{% load i18n staticfiles thumbnail cms_tags apphooks_config_tags %}
+
+<article class="article
+    {% if article.is_featured %} featured{% endif %}
+    {% if not article.published %} unpublished{% endif %}">
+
+    {# The image is only shown on the detail view by using the condition "and detail_view" #}
+    {% if article.featured_image_id and detail_view %}
+        <p>
+            <img src="{% thumbnail article.featured_image.image 800x450 crop subject_location=article.featured_image.subject_location %}" alt="{{ article.featured_image.alt }}">
+        </p>
+    {% endif %}
+
+    {% if article.categories %}
+        <p>
+            {% for category in article.categories.all %}
+                <a href="{% namespace_url 'article-list-by-category' category.slug namespace=namespace default='' %}">{{ category.name }}</a>
+                {% if not forloop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+    {% endif %}
+
+    <h2>
+        {% if not detail_view %}
+            <a href="{% namespace_url 'article-detail' article.slug namespace=namespace default='' %}">{% render_model article "title" %}</a>
+        {% else %}
+            {% render_model article "title" %}
+        {% endif %}
+    </h2>
+
+    <p>{{ article.publishing_date|date }}</p>
+
+    {% include "aldryn_newsblog/includes/author.html" with author=article.author %}
+
+    {% if article.tags %}
+        <p>
+            {% for tag in article.tags.all %}
+                <a href="{% namespace_url 'article-list-by-tag' tag=tag.slug namespace=namespace default='' %}">{{ tag.name }}</a>
+            {% endfor %}
+        </p>
+    {% endif %}
+
+    {% render_model article "lead_in" %}
+
+    {% if detail_view %}
+        {% render_placeholder article.content language placeholder_language %}
+    {% endif %}
+</article>

--- a/aldryn_newsblog/templates/aldryn_newsblog/includes/author.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/includes/author.html
@@ -1,0 +1,15 @@
+{% load i18n staticfiles thumbnail apphooks_config_tags %}
+
+{% if author %}
+    <p>
+        <a href="{% namespace_url "article-list-by-author" author.slug namespace=namespace default='' %}">
+            {% if author.visual %}
+                {% thumbnail author.visual "50x50" crop upscale subject_location=author.visual.subject_location as author_image %}
+                <img src="{{ author_image.url }}" width="50" height="50" alt="{{ author.name }}">
+            {% endif %}
+            {{ author.name }}
+        </a>
+    </p>
+    {% if author.function %}<p>{{ author.function }}</p>{% endif %}
+    {% if author.article_count %}<p>{{ author.article_count }}</p>{% endif %}
+{% endif %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/includes/pagination.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/includes/pagination.html
@@ -1,0 +1,33 @@
+{% load i18n %}
+
+<ul>
+    {% if page_obj.has_previous %}
+        <li>
+            <a href="{{ request.path }}?page={{ page_obj.previous_page_number }}">
+                {% trans "Previous" %}
+            </a>
+        </li>
+    {% endif %}
+
+    {% for num in page_obj.paginator.page_range %}
+        {% if num %}
+            {% if page_obj.number == num %}
+                <li class="active"><span>{{ num }}</span></li>
+            {% else %}
+                <li><a href="{{ request.path }}?page={{ num }}">{{ num }}</a></li>
+            {% endif %}
+        {% else %}
+            <li><a href="{{ request.path }}?page={{ num|add:"5" }}">...</a></li>
+        {% endif %}
+    {% empty %}
+        <li class="active"><span>1</span></li>
+    {% endfor %}
+
+    {% if page_obj.has_next %}
+        <li>
+            <a href="{{ request.path }}?page={{ page_obj.next_page_number }}">
+                {% trans "Next" %}
+            </a>
+        </li>
+    {% endif %}
+</ul>

--- a/aldryn_newsblog/templates/aldryn_newsblog/includes/search_results.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/includes/search_results.html
@@ -1,0 +1,27 @@
+{% extends "aldryn_newsblog/base.html" %}
+{% load i18n apphooks_config_tags %}
+
+{% block newsblog_content %}
+    <ul>
+        <h3>{% blocktrans with query=query %}Most recent articles containing "<strong>{{ query }}</strong>"{% endblocktrans %}</h3>
+        {% for article in object_list %}
+            <li{% if not article.is_published %} class="unpublished"{% endif %}>
+                <a href="{% namespace_url "article-detail" article.slug namespace=view.app_config.namespace default='' %}">
+                    <strong>
+                        {% for category in article.categories.all %}
+                            {{ category.name }}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
+                    </strong>
+                    {{ article.title }}<br />
+                    {{ article.lead_in|striptags|truncatewords:"10"|safe }}
+                </a>
+            </li>
+        {% empty %}
+            {% if query %}
+                <p>{% blocktrans with query=query %}No articles found{% endblocktrans %}</p>
+            {% else %}
+                <p>{% trans "Enter a query above" %}</p>
+            {% endif %}
+        {% endfor %}
+    </ul>
+{% endblock %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/archive.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/archive.html
@@ -1,0 +1,26 @@
+{% load i18n apphooks_config_tags %}
+
+{% regroup dates by date.year as years %}
+{% with current_year=year current_month=month %}
+
+<ul>
+    {% for year in years %}
+        <li>
+            <a href="{% namespace_url 'article-list-by-year' year=year.grouper namespace=instance.app_config.namespace default='' %}">{{ year.grouper }}</a>
+            <ul>
+                {% for month in year.list %}
+                    <li>
+                        <a href="{% namespace_url 'article-list-by-month' year=year.grouper month=month.date|date:"n" namespace=instance.app_config.namespace default='' %}"
+                            {% if year.grouper == current_year and month.date.month == current_month %} class="active"{% endif %}>
+                                {{ month.date|date:"F" }} <span>{{ month.num_articles }}</span>
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+        </li>
+    {% empty %}
+        <li>{% trans "No items available" %}</li>
+    {% endfor %}
+</ul>
+
+{% endwith %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/article_search.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/article_search.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+{# submission of this form will forward to "includes/search_results.html" #}
+{# this form can also be submitted using ajax and "includes/search_results.html" is returned #}
+<form action="{{ query_url }}" method="get">
+    <label for="search-plugin-{{ instance.pk }}">{% trans "Keyword search" %}</label>
+    <input type="text" name="q" id="search-plugin-{{ instance.pk }}" placeholder="{% trans 'Keyword' %}">
+
+    <input type="hidden" name="max_articles" value="{{ instance.max_articles }}">
+    <button type="submit">{% trans "Go" %}</button>
+</form>

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/authors.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/authors.html
@@ -1,0 +1,11 @@
+{% load i18n %}
+
+<ul>
+    {% for author in authors_list %}
+        <li>
+            {% include "aldryn_newsblog/includes/author.html" with author_view="true" namespace=instance.app_config.namespace %}
+        </li>
+    {% empty %}
+        <li>{% trans "No items available" %}</li>
+    {% endfor %}
+</ul>

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/categories.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/categories.html
@@ -1,0 +1,13 @@
+{% load i18n apphooks_config_tags %}
+
+<ul>
+    <li{% if not newsblog_category %} class="active"{% endif %}>
+        <a href="{% namespace_url "article-list" namespace=instance.app_config.namespace default='' %}">{% trans "All" %}</a>
+    </li>
+    {% for category in categories %}
+        <li{% if newsblog_category.id == category.id %} class="active"{% endif %}>
+            <a href="{% namespace_url "article-list-by-category" category.slug namespace=instance.app_config.namespace default='' %}">{{ category.name }}</a>
+            <span>{{ category.article_count }}</span>
+        </li>
+    {% endfor %}
+</ul>

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/featured_articles.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/featured_articles.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+
+{% for article in articles_list %}
+    {% include "aldryn_newsblog/includes/article.html" with namespace=instance.app_config.namespace %}
+{% empty %}
+    <p>{% trans "No items available" %}</p>
+{% endfor %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/latest_articles.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/latest_articles.html
@@ -1,0 +1,7 @@
+{% load i18n %}
+
+{% for article in article_list %}
+    {% include "aldryn_newsblog/includes/article.html" with namespace=instance.app_config.namespace %}
+{% empty %}
+    <p>{% trans "No items available" %}</p>
+{% endfor %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/related_articles.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/related_articles.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+
+<ul>
+    {% for article in article_list %}
+        <li>
+            <h3><a href="{{ article.get_absolute_url }}">{{ article.title }}</a></h3>
+            <p>{% trans "by" %} <a href="#">{{ article.author }}</a> {{ article.publishing_date|date }}</p>
+        </li>
+    {% empty %}
+        <li>{% trans "No items available" %}</li>
+    {% endfor %}
+</ul>

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/tags.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/tags.html
@@ -1,0 +1,15 @@
+{% load i18n apphooks_config_tags %}
+
+<ul>
+    <li{% if not newsblog_tag %} class="active"{% endif %}>
+        <a href="{% namespace_url "article-list" namespace=instance.app_config.namespace default='' %}">{% trans "All" %}</a>
+    </li>
+    {% for tag in tags %}
+        <li{% if newsblog_tag.id == tag.id %} class="active"{% endif %}>
+            <a href="{% namespace_url "article-list-by-tag" tag.slug namespace=instance.app_config.namespace default='' %}">
+                {{ tag.name }}
+                <span>{{ tag.article_count }}</span>
+            </a>
+        </li>
+    {% endfor %}
+</ul>


### PR DESCRIPTION
This will enable us to use the newsblog without boilerplates and as fallback on Aldryn Cloud if there is no boilerplate folder specified.