### PR TITLE
Simplify templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+
+1.2.0 (UNRELEASED)
+-------------------
+
+* Remove unused render_placeholder configs
+* Add static_placeholders where necessary
+* Simplify templates
+
+
 1.1.1 (2016-02-12)
 -------------------
 

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/article_detail.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/article_detail.html
@@ -2,13 +2,13 @@
 {% load i18n cms_tags apphooks_config_tags %}
 
 {% block title %}{{ article.title }} - {{ block.super }}{% endblock %}
+{% block breadcrumb %}{% endblock %}
 
 {% block newsblog_content %}
-    {% render_placeholder view.config.placeholder_detail_top %}
     <div class="aldryn-newsblog-detail">
         {% include "aldryn_newsblog/includes/article.html" with detail_view="true" %}
     </div>
-    {% render_placeholder view.config.placeholder_detail_bottom %}
+    {% static_placeholder "newsblog_social" %}
 {% endblock %}
 
 {% block newsblog_footer %}
@@ -27,5 +27,5 @@
             {% endif %}
         </ul>
     </div>
-    {% render_placeholder view.config.placeholder_detail_footer %}
+    {% static_placeholder "newsblog_comments" %}
 {% endblock %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/article_list.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/article_list.html
@@ -2,7 +2,6 @@
 {% load i18n cms_tags %}
 
 {% block newsblog_content %}
-    {% render_placeholder view.config.list_view_placeholder language placeholder_language %}
     <div class="aldryn-newsblog-list">
         {% for article in article_list %}
             {% include "aldryn_newsblog/includes/article.html" %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/base.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/base.html
@@ -1,8 +1,3 @@
 {% extends CMS_TEMPLATE %}
 
-{% block extend_breadcrumb %}
-    {{ block.super }}
-    {% block newsblog_breadcrumb %}{% endblock newsblog_breadcrumb %}
-{% endblock extend_breadcrumb %}
-
 {% block content %}{% endblock content %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/fullwidth.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/fullwidth.html
@@ -5,11 +5,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-16 col-md-push-4">
-                {% if view.show_header %}
-                    {% render_placeholder view.config.placeholder_base_top %}
-                {% endif %}
                 <div class="aldryn aldryn-newsblog">
-                    {% block newsblog_title %}{% endblock %}
                     {% block newsblog_content %}{% endblock %}
                 </div>
             </div>

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/includes/article.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/includes/article.html
@@ -1,71 +1,61 @@
 {% load i18n apphooks_config_tags cms_tags sekizai_tags staticfiles thumbnail %}
 
 <article class="aldryn-newsblog-article{% if article.is_featured %} aldryn-newsblog-featured{% endif %}{% if not article.published %} unpublished{% endif %}{% if article.future %} future{% endif %}">
-    {% block newsblog_visual %}
-        {% if article.featured_image_id %}
-            <p class="visual">
-                {% if not detail_view %}
-                    <a href="{{ article.get_absolute_url }}">
-                {% endif %}
-                <img src="{% thumbnail article.featured_image.image 800x450 crop subject_location=article.featured_image.subject_location %}" alt="{{ article.featured_image.alt }}" class="img-responsive">
-                {% if not detail_view %}
-                    </a>
-                {% endif %}
-            </p>
-        {% endif %}
-    {% endblock newsblog_visual %}
-
-    {% block newsblog_categories %}
-        {% if article.categories %}
-            <p class="category">
-                {% for category in article.categories.all %}
-                    <a href="{% namespace_url 'article-list-by-category' category.slug namespace=namespace default='' %}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}
-                {% endfor %}
-            </p>
-        {% endif %}
-    {% endblock newsblog_categories %}
-
-    {% block newsblock_title %}
-        <h2>
+    {% if article.featured_image_id %}
+        <p class="visual">
             {% if not detail_view %}
-                <a href="{% namespace_url 'article-detail' article.slug namespace=namespace default='' %}">{% render_model article "title" %}</a>
-            {% else %}
-                {% render_model article "title" %}
+                <a href="{{ article.get_absolute_url }}">
             {% endif %}
-        </h2>
-    {% endblock newsblock_title %}
+            <img src="{% thumbnail article.featured_image.image 800x450 crop subject_location=article.featured_image.subject_location %}" alt="{{ article.featured_image.alt }}" class="img-responsive">
+            {% if not detail_view %}
+                </a>
+            {% endif %}
+        </p>
+    {% endif %}
 
-    {% block newsblog_meta %}
+    {% if article.categories %}
+        <p class="category">
+            {% for category in article.categories.all %}
+                <a href="{% namespace_url 'article-list-by-category' category.slug namespace=namespace default='' %}">{{ category.name }}</a>{% if not forloop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+    {% endif %}
+
+    <h2>
         {% if not detail_view %}
-            <div class="lead">
-                {% render_model article "lead_in" "" "" "truncatewords:'20'" %}
-            </div>
+            <a href="{% namespace_url 'article-detail' article.slug namespace=namespace default='' %}">{% render_model article "title" %}</a>
+        {% else %}
+            {% render_model article "title" %}
         {% endif %}
+    </h2>
 
-        {% include "aldryn_newsblog/includes/author.html" with author=article.author %}
+    {% if not detail_view %}
+        <div class="lead">
+            {% render_model article "lead_in" "" "" "truncatewords:'20'" %}
+        </div>
+    {% endif %}
 
-        {% if article.tags and detail_view %}
-            <p class="tags">
-                {% for tag in article.tags.all %}
-                    <a href="{% namespace_url 'article-list-by-tag' tag=tag.slug namespace=namespace default='' %}">{{ tag.name }}</a>
-                {% endfor %}
-            </p>
-        {% endif %}
+    {% include "aldryn_newsblog/includes/author.html" with author=article.author %}
 
-        {% if detail_view %}
-            <div class="lead">
-                {% render_model article "lead_in" %}
-            </div>
-        {% endif %}
-    {% endblock newsblog_meta %}
+    {% if article.tags and detail_view %}
+        <p class="tags">
+            {% for tag in article.tags.all %}
+                <a href="{% namespace_url 'article-list-by-tag' tag=tag.slug namespace=namespace default='' %}">{{ tag.name }}</a>
+            {% endfor %}
+        </p>
+    {% endif %}
 
-    {% block newsblog_content %}
-        {% if detail_view %}
-            <div class="content">
-                {% render_placeholder article.content language placeholder_language %}
-            </div>
-        {% endif %}
-    {% endblock newsblog_content %}
+    {% if detail_view %}
+        <div class="lead">
+            {% render_model article "lead_in" %}
+        </div>
+    {% endif %}
+
+    {% if detail_view %}
+        <div class="content">
+            {% render_placeholder article.content language placeholder_language %}
+        </div>
+    {% endif %}
 </article>
 
 {% addtoblock "css" %}<link rel="stylesheet" href="{% static 'css/aldryn-newsblog/article.css' %}">{% endaddtoblock %}

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/two_column.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/two_column.html
@@ -6,16 +6,14 @@
         <div class="row">
             <div class="col-md-17">
                 {% if view.show_header %}
-                    {% render_placeholder view.config.placeholder_base_top %}
+                    {% static_placeholder "newsblog_feature" %}
                 {% endif %}
                 <div class="aldryn aldryn-newsblog">
-                    {% block newsblog_title %}{% endblock %}
                     {% block newsblog_content %}{% endblock %}
-                    {% block newsblog_footer %}{% endblock %}
                 </div>
             </div>
             <div class="col-md-7 aldryn-newsblog aldryn-newsblog-sidebar">
-                {% render_placeholder view.config.placeholder_base_sidebar %}
+                {% static_placeholder "newsblog_sidebar" %}
                 {% block newsblog_sidebar %}{% endblock %}
             </div>
         </div>

--- a/aldryn_newsblog/cms_toolbar.py
+++ b/aldryn_newsblog/cms_toolbar.py
@@ -27,7 +27,7 @@ class NewsBlogToolbar(CMSToolbar):
     watch_models = [Article, ]
     supported_apps = ('aldryn_newsblog',)
 
-    def get_on_delete_redirect_url(self, article, language=None):
+    def get_on_delete_redirect_url(self, article, language):
         with override(language):
             url = reverse(
                 '{0}:article-list'.format(article.app_config.namespace))

--- a/aldryn_newsblog/cms_toolbar.py
+++ b/aldryn_newsblog/cms_toolbar.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _, get_language_from_request
+from django.utils.translation import (
+    ugettext as _, get_language_from_request, override)
 
 from cms.toolbar_base import CMSToolbar
 from cms.toolbar_pool import toolbar_pool
@@ -26,8 +27,10 @@ class NewsBlogToolbar(CMSToolbar):
     watch_models = [Article, ]
     supported_apps = ('aldryn_newsblog',)
 
-    def get_on_delete_redirect_url(self, article):
-        url = reverse('{0}:article-list'.format(article.app_config.namespace))
+    def get_on_delete_redirect_url(self, article, language=None):
+        with override(language):
+            url = reverse(
+                '{0}:article-list'.format(article.app_config.namespace))
         return url
 
     def __get_newsblog_config(self):
@@ -116,7 +119,8 @@ class NewsBlogToolbar(CMSToolbar):
                                     active=True)
 
             if delete_article_perm and article:
-                redirect_url = self.get_on_delete_redirect_url(article)
+                redirect_url = self.get_on_delete_redirect_url(
+                    article, language=language)
                 url = get_admin_url('aldryn_newsblog_article_delete',
                                     [article.pk, ])
                 menu.add_modal_item(_('Delete this article'), url=url,

--- a/aldryn_newsblog/templates/aldryn_newsblog/article_detail.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/article_detail.html
@@ -1,5 +1,5 @@
 {% extends "aldryn_newsblog/base.html" %}
-{% load i18n apphooks_config_tags %}
+{% load i18n cms_tags apphooks_config_tags %}
 
 {% block title %}
     {{ article.title }} - {{ block.super }}
@@ -7,6 +7,8 @@
 
 {% block newsblog_content %}
     {% include "aldryn_newsblog/includes/article.html" with detail_view="true" %}
+
+    {% static_placeholder "newsblog_social" %}
 
     <ul>
         {% if prev_article %}

--- a/aldryn_newsblog/templates/aldryn_newsblog/plugins/related_articles.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/plugins/related_articles.html
@@ -1,12 +1,14 @@
 {% load i18n %}
 
-<ul>
-    {% for article in article_list %}
-        <li>
-            <h3><a href="{{ article.get_absolute_url }}">{{ article.title }}</a></h3>
-            <p>{% trans "by" %} <a href="#">{{ article.author }}</a> {{ article.publishing_date|date }}</p>
-        </li>
-    {% empty %}
-        <li>{% trans "No items available" %}</li>
-    {% endfor %}
-</ul>
+{% if article %}
+    <ul>
+        {% for article in article_list %}
+            <li>
+                <h3><a href="{{ article.get_absolute_url }}">{{ article.title }}</a></h3>
+                <p>{% trans "by" %} <a href="#">{{ article.author }}</a> {{ article.publishing_date|date }}</p>
+            </li>
+        {% empty %}
+            <li>{% trans "No items available" %}</li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/aldryn_newsblog/tests/frontend/integration/pages/page.newsblog.crud.js
+++ b/aldryn_newsblog/tests/frontend/integration/pages/page.newsblog.crud.js
@@ -27,11 +27,11 @@ var page = {
         '.cms-toolbar-item-navigation a[href="/en/admin/"]')),
     sideMenuIframe: element(by.css('.cms-sideframe-frame iframe')),
     pagesLink: element(by.css('.model-page > th > a')),
-    addPageLink: element(by.css('.sitemap-noentry .addlink')),
+    addPageLink: element(by.css('.object-tools .addlink')),
     titleInput: element(by.id('id_title')),
     slugErrorNotification: element(by.css('.errors.slug')),
     saveButton: element(by.css('.submit-row [name="_save"]')),
-    editPageLink: element(by.css('.col-preview [href*="preview/"]')),
+    editPageLink: element(by.css('.cms-tree-item-preview [href*="preview/"]')),
     testLink: element(by.cssContainingText('a', 'Test')),
     sideFrameClose: element(by.css('.cms-sideframe-close')),
 

--- a/aldryn_newsblog/tests/frontend/integration/pages/page.newsblog.crud.js
+++ b/aldryn_newsblog/tests/frontend/integration/pages/page.newsblog.crud.js
@@ -56,15 +56,15 @@ var page = {
         '.results th > [href*="/aldryn_newsblog/article/"]')),
 
     // adding article to the page
-    aldrynNewsBlogBlock: element(by.css('.aldryn-newsblog-list')),
+    aldrynNewsBlogBlock: element(by.css('article')),
     advancedSettingsOption: element(by.css(
         '.cms-toolbar-item-navigation [href*="advanced-settings"]')),
     modalIframe: element(by.css('.cms-modal-frame iframe')),
     applicationSelect: element(by.id('application_urls')),
     newsBlogOption: element(by.css('option[value="NewsBlogApp"]')),
     saveModalButton: element(by.css('.cms-modal-buttons .cms-btn-action')),
-    newsBlogMetaBlock: element(by.css('.aldryn-newsblog-meta')),
-    articleLink: element(by.css('.aldryn-newsblog-list h2 > a')),
+    newsBlogMetaBlock: element(by.css('p')),
+    articleLink: element(by.css('article h2 > a')),
 
     // deleting article
     deleteButton: element(by.css('.deletelink-box a')),

--- a/aldryn_newsblog/tests/test_plugins.py
+++ b/aldryn_newsblog/tests/test_plugins.py
@@ -11,6 +11,7 @@ from django.utils.translation import force_text
 
 from aldryn_newsblog.models import NewsBlogConfig
 from cms import api
+from cms.models import StaticPlaceholder
 
 from . import NewsBlogTestCase
 
@@ -243,7 +244,8 @@ class TestRelatedArticlesPlugin(NewsBlogTestCase):
 
     def test_related_articles_plugin(self):
         main_article = self.create_article(app_config=self.app_config)
-        self.placeholder = self.app_config.placeholder_detail_top
+        self.placeholder = StaticPlaceholder.objects.get_or_create(
+            code='newsblog_social', site__isnull=True)[0].draft
         api.add_plugin(self.placeholder, 'NewsBlogRelatedPlugin', self.language)
         self.plugin = self.placeholder.get_plugins()[0].get_plugin_instance()[0]
         self.plugin.save()

--- a/aldryn_newsblog/tests/test_plugins.py
+++ b/aldryn_newsblog/tests/test_plugins.py
@@ -244,11 +244,18 @@ class TestRelatedArticlesPlugin(NewsBlogTestCase):
 
     def test_related_articles_plugin(self):
         main_article = self.create_article(app_config=self.app_config)
-        self.placeholder = StaticPlaceholder.objects.get_or_create(
-            code='newsblog_social', site__isnull=True)[0].draft
-        api.add_plugin(self.placeholder, 'NewsBlogRelatedPlugin', self.language)
-        self.plugin = self.placeholder.get_plugins()[0].get_plugin_instance()[0]
-        self.plugin.save()
+        static_placeholder = StaticPlaceholder.objects.get_or_create(
+            code='newsblog_social',
+            site__isnull=True,
+        )[0]
+        placeholder = static_placeholder.draft
+        api.add_plugin(placeholder, 'NewsBlogRelatedPlugin', self.language)
+
+        static_placeholder.publish(None, language=self.language, force=True)
+
+        plugin = placeholder.get_plugins()[0].get_plugin_instance()[0]
+        plugin.save()
+
         self.plugin_page.publish(self.language)
 
         main_article.save()

--- a/aldryn_newsblog/tests/test_plugins.py
+++ b/aldryn_newsblog/tests/test_plugins.py
@@ -113,8 +113,8 @@ class TestAuthorsPlugin(TestAppConfigPluginsBase):
 
         response = self.client.get(self.plugin_page.get_absolute_url())
         response_content = force_text(response.content)
-        pattern = '<p class="author"><a href="{url}"></a>'
-        pattern += '</p>\s*<p[^>]*></p>\s*<p class="badge">{num}</p>'
+        pattern = '<p>\s*<a href="{url}">\s*</a>\s*</p>'
+        pattern += '\s*<p>{num}</p>'
         author1_pattern = pattern.format(
             num=3,
             url=reverse(
@@ -168,7 +168,7 @@ class TestCategoriesPlugin(TestAppConfigPluginsBase):
 
         response = self.client.get(self.plugin_page.get_absolute_url())
         response_content = force_text(response.content)
-        pattern = '<span[^>]*>{num}</span>\s*<a href=[^>]*>{name}</a>'
+        pattern = '<a href=[^>]*>{name}</a>\s*<span[^>]*>{num}</span>'
         needle1 = pattern.format(num=3, name=self.category1.name)
         needle2 = pattern.format(num=5, name=self.category2.name)
         self.assertRegexpMatches(response_content, needle1)

--- a/test_settings.py
+++ b/test_settings.py
@@ -33,7 +33,6 @@ HELPER_SETTINGS = {
             'aldryn_newsblog', 'tests', 'templates'),
     ),
     'ALDRYN_NEWSBLOG_TEMPLATE_PREFIXES': [('dummy', 'dummy'), ],
-    'ALDRYN_BOILERPLATE_NAME': 'bootstrap3',
     'CMS_PERMISSION': True,
     'SITE_ID': 1,
     'LANGUAGES': (
@@ -167,7 +166,7 @@ def run():
     from djangocms_helper import runner
     # --boilerplate option will ensure correct boilerplate settings are
     # added to settings
-    runner.cms('aldryn_newsblog', extra_args=['--boilerplate'])
+    runner.cms('aldryn_newsblog', extra_args=[])
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
The goal of this Pull Request is:

- Simplify template structure
- Remove unnecessary placeholder and blocks
- In general make everything simple for easier explanation

We also want to remove ``render_placeholder view.config`` and later only mention it in the documentation (separate PR will follow).