### PR TITLE
Fixed an empty <p> tag

### DIFF
--- a/aldryn_newsblog/templates/aldryn_newsblog/includes/article.html
+++ b/aldryn_newsblog/templates/aldryn_newsblog/includes/article.html
@@ -11,7 +11,7 @@
         </p>
     {% endif %}
 
-    {% if article.categories %}
+    {% if article.categories.exists %}
         <p>
             {% for category in article.categories.all %}
                 <a href="{% namespace_url 'article-list-by-category' category.slug namespace=namespace default='' %}">{{ category.name }}</a>


### PR DESCRIPTION
An empty <p> tag was generated if no categories were assigned to a post.