### PR TITLE
Article admin change form: remove possibility to add related article.

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -82,6 +82,10 @@ class ArticleAdminForm(TranslatableModelForm):
         # Don't allow app_configs to be added here. The correct way to add an
         # apphook-config is to create an apphook on a cms Page.
         self.fields['app_config'].widget.can_add_related = False
+        # Don't allow related articles to be added here.
+        # doesn't makes much sense to add articles from another article other
+        # than save and add another.
+        self.fields['related'].widget.can_add_related = False
 
 
 class ArticleAdmin(


### PR DESCRIPTION
doesn't makes sense to add an artilce from another article change form. Use save and add another instead.