### PR TITLE
Article detail view: Adjust PreviewModeMixin to show not publishe items not in edit mode

### DIFF
--- a/aldryn_newsblog/views.py
+++ b/aldryn_newsblog/views.py
@@ -65,7 +65,12 @@ class PreviewModeMixin(EditModeMixin):
     """
     def get_queryset(self):
         qs = super(PreviewModeMixin, self).get_queryset()
-        if not self.edit_mode:
+        # check if user can see unpublished items. this will allow to switch
+        # to edit mode instead of 404 on article detail page. CMS handles the
+        # permissions.
+        user = self.request.user
+        user_can_edit = user.is_staff or user.is_superuser
+        if not (self.edit_mode or user_can_edit):
             qs = qs.published()
         language = translation.get_language()
         qs = qs.active_translations(language).namespace(self.namespace)


### PR DESCRIPTION
This will fix a 404 on detail page if article was not published, and the user is not in edit mode.

**Note** previously not published articles were filtered out for any user if edit mode was off.