### PR TITLE
disable search data by default

### DIFF
--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -81,7 +81,7 @@ class Article(TranslatedAutoSlugifyMixin,
     update_search_on_save = getattr(
         settings,
         'ALDRYN_NEWSBLOG_UPDATE_SEARCH_DATA_ON_SAVE',
-        True
+        False
     )
 
     translations = TranslatedFields(


### PR DESCRIPTION
Currently this feature is not very usable as it requires the developer to configure full text search.
This being the case, currently any modification to a plugin inside the article content will trigger this and take a lot of precious time from the request/response cycle.