### PR TITLE
Bump django-sortedm2m version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
     'django-filer>=0.9.9',
     'django-parler>=1.4',
     'django-reversion>=1.8.2,<1.11',
-    'django-sortedm2m',
+    'django-sortedm2m>=1.2.2',
     'django-taggit',
     'lxml',
     'pytz',


### PR DESCRIPTION
This version of django-sortedm2m contains the fix for django 1.8+