### PR TITLE
Changed `truncatewords` to `truncatewords_html` in article lead

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ CHANGELOG
 ------------------
 
 * Updated translation setup for transifex
+* Fixed bootstrap3 article template sometimes causing broken pages
 
 
 1.2.2 (2016-05-19)

--- a/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/includes/article.html
+++ b/aldryn_newsblog/boilerplates/bootstrap3/templates/aldryn_newsblog/includes/article.html
@@ -31,7 +31,7 @@
 
     {% if not detail_view %}
         <div class="lead">
-            {% render_model article "lead_in" "" "" "truncatewords:'20'" %}
+            {% render_model article "lead_in" "" "" "truncatewords_html:'20'" %}
         </div>
     {% endif %}
 


### PR DESCRIPTION
Since lead_in could contain markup it could happen that it was truncated in the middle of the tag, causing unclosed html
tags which in turn would break the rest of the page (and cms, so it couldn't be edited to fix, unless on detail page).

Fixed #406 