### PR TITLE
Relaxed sortedm2m version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ REQUIREMENTS = [
     'django-filer>=0.9.9',
     'django-parler>=1.4',
     'django-reversion>=1.8.2,<1.11',
-    'django-sortedm2m>=1.2.2,<1.3.0',
+    'django-sortedm2m>=1.2.2,!=1.3.0,!=1.3.1',
     'django-taggit',
     'lxml',
     'pytz',


### PR DESCRIPTION
Version 1.3.0 of django-sortedm2m introduced a regression, which is fixed in 1.3.2