### PR TITLE
Fixed aldryn_translation_tools not being added to INSTALLED_APPS on Aldryn

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.2.4 (unreleased)
+------------------
+
+* Fixed aldryn_translation_tools not being added to INSTALLED_APPS on Aldryn
+
+
 1.2.3 (2016-06-28)
 ------------------
 

--- a/addon.json
+++ b/addon.json
@@ -8,6 +8,7 @@
         "aldryn_newsblog",
         "aldryn_people",
         "aldryn_reversion",
+        "aldryn_translation_tools",
         "easy_thumbnails",
         "filer",
         "sortedm2m",

--- a/test_requirements/base.txt
+++ b/test_requirements/base.txt
@@ -2,7 +2,6 @@ aldryn-search>=0.2.12
 coverage>=3.7.1
 dj-database-url
 django-classy-tags
-django-haystack
 django-sekizai
 django-treebeard>=2.0
 djangocms-admin-style

--- a/test_requirements/django-1.6.txt
+++ b/test_requirements/django-1.6.txt
@@ -1,6 +1,7 @@
 django>=1.6,<1.7
 South
 django-reversion<1.8.3
+django-haystack<2.5
 
 
 

--- a/test_requirements/django-1.7.txt
+++ b/test_requirements/django-1.7.txt
@@ -1,6 +1,7 @@
 django>=1.7.4,<1.8
 
 django-reversion>=1.8.2,<1.9
+django-haystack
 
 
 

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -1,6 +1,7 @@
 django>=1.8,<1.9
 
 django-reversion>=1.9.3,<1.10
+django-haystack
 
 
 

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -1,6 +1,7 @@
 django>=1.9,<1.10
 
 django-reversion>=1.9.4,<1.11
+django-haystack
 
 # Django 1.9 compatible packages
 aldryn-boilerplates>=0.7.4


### PR DESCRIPTION
which resulted in 404s. problem is hard to catch, because all other essential addons add it