### PR TITLE
Fix for issue 307 - articles with just whitespace for a title.

### DIFF
--- a/aldryn_newsblog/admin.py
+++ b/aldryn_newsblog/admin.py
@@ -99,6 +99,13 @@ class ArticleAdminForm(TranslatableModelForm):
                 hasattr(self.fields['related'], 'widget')):
             self.fields['related'].widget.can_add_related = False
 
+    def clean(self):
+        cleaned_data = super(ArticleAdminForm, self).clean()
+        title = cleaned_data.get('title')
+        if title and title.strip() == '':
+            self.add_error('title', _("This field is required"))
+        return cleaned_data
+
 
 class ArticleAdmin(
     AllTranslationsMixin,

--- a/aldryn_newsblog/tests/__init__.py
+++ b/aldryn_newsblog/tests/__init__.py
@@ -96,10 +96,18 @@ class NewsBlogTestsMixin(object):
             owner = kwargs['owner']
         except KeyError:
             owner = author.user
+        try:
+            title = kwargs['title']
+        except KeyError:
+            title = self.rand_str()
+        try:
+            slug = kwargs['slug']
+        except KeyError:
+            slug = self.rand_str()
 
         fields = {
-            'title': self.rand_str(),
-            'slug': self.rand_str(),
+            'title': title,
+            'slug': slug,
             'author': author,
             'owner': owner,
             'app_config': self.app_config,

--- a/aldryn_newsblog/tests/test_views.py
+++ b/aldryn_newsblog/tests/test_views.py
@@ -11,9 +11,11 @@ from random import randint
 from django.conf import settings
 from django.core.files import File as DjangoFile
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.forms import model_to_dict
 from django.utils.timezone import now
 from django.utils.translation import override
 
+from aldryn_newsblog.admin import ArticleAdminForm
 from aldryn_newsblog.models import Article, NewsBlogConfig
 from aldryn_newsblog.search_indexes import ArticleIndex
 from cms.utils.i18n import get_current_language, force_language
@@ -543,6 +545,14 @@ class TestVariousViews(NewsBlogTestCase):
                     for _ in range(11)]
         with self.assertRaises(NoReverseMatch):
             self.client.get(articles[0].get_absolute_url())
+
+    def test_empty_title(self):
+        article = self.create_article(title=' ')
+        self.assertEqual(article.title, ' ')
+
+        form_data = model_to_dict(article)
+        form = ArticleAdminForm(data=form_data)
+        self.assertFalse(form.is_valid())
 
 
 class TestIndex(NewsBlogTestCase):


### PR DESCRIPTION
This resolves the issue with the creation of articles with only whitespace as a title.