### PR TITLE
Fix #482 - add support for new way of render plugin introduced in django-cms 3.4.0

### DIFF
--- a/aldryn_newsblog/tests/__init__.py
+++ b/aldryn_newsblog/tests/__init__.py
@@ -22,10 +22,8 @@ from cms.apphook_pool import apphook_pool
 from cms.appresolver import clear_app_resolvers
 from cms.exceptions import AppAlreadyRegistered
 from cms.test_utils.testcases import CMSTestCase, TransactionCMSTestCase
-from cms.utils.conf import get_cms_setting
-
 from cms.toolbar.toolbar import CMSToolbar
-
+from cms.utils.conf import get_cms_setting
 
 from parler.utils.context import switch_language
 
@@ -186,8 +184,11 @@ class NewsBlogTestsMixin(object):
         self.language = settings.LANGUAGES[0][0]
         self.root_page = api.create_page(
             'root page', self.template, self.language, published=True)
-        self.app_config = NewsBlogConfig.objects.create(
-            namespace='NBNS', paginate_by=15)
+        self.app_config = NewsBlogConfig.objects.language(self.language).create(
+            app_title='news_blog',
+            namespace='NBNS',
+            paginate_by=15,
+        )
         self.page = api.create_page(
             'page', self.template, self.language, published=True,
             parent=self.root_page,
@@ -208,6 +209,11 @@ class NewsBlogTestsMixin(object):
 
 class CleanUpMixin(object):
     apphook_object = None
+
+    def setUp(self):
+        super(CleanUpMixin, self).setUp()
+        apphook_object = self.get_apphook_object()
+        self.reload_urls(apphook_object)
 
     def tearDown(self):
         """

--- a/aldryn_newsblog/tests/test_search.py
+++ b/aldryn_newsblog/tests/test_search.py
@@ -21,6 +21,9 @@ class ArticleIndexingTests(NewsBlogTestCase):
         lead_in = 'Hello! this text will be searchable.'
 
         article = self.create_article(lead_in=lead_in)
+        # If set ALDRYN_NEWSBLOG_UPDATE_SEARCH_DATA_ON_SAVE this will do
+        # automatically
+        article.search_data = article.get_search_data()
 
         index = self.get_index()
 

--- a/aldryn_newsblog/utils/utilities.py
+++ b/aldryn_newsblog/utils/utilities.py
@@ -122,8 +122,7 @@ def render_plugin(request, plugin_instance):
         )
     else:
         renderer = ContentRenderer(request)
-        context = RequestContext(request)
-        context['request'] = request
+        context = {'request': request}
         return renderer.render_plugin(plugin_instance, context)
 
 

--- a/test_requirements/django-1.8.txt
+++ b/test_requirements/django-1.8.txt
@@ -6,4 +6,6 @@ django-haystack
 django-mptt>=0.7
 django-polymorphic>=0.7
 
+aldryn-apphooks-config>=0.2.4,<0.4.0
+
 -r base.txt

--- a/test_requirements/django-1.9.txt
+++ b/test_requirements/django-1.9.txt
@@ -5,6 +5,8 @@ django-haystack
 # Django 1.9 compatible packages
 aldryn-boilerplates>=0.7.4
 
+aldryn-apphooks-config>=0.2.4,<0.4.0
+
 # NOTE: These are for Filer
 django-mptt>=0.7
 django-polymorphic>=0.7


### PR DESCRIPTION
* Also in `get_plugin_index_data` change `instance` name to
`plugin_instance` to improve function readability