### PR TITLE
Fix FieldError on creating newsblog article in cms wizard

### DIFF
--- a/aldryn_newsblog/models.py
+++ b/aldryn_newsblog/models.py
@@ -235,9 +235,6 @@ class Article(TranslatedAutoSlugifyMixin,
 
         # Ensure there is an owner.
         if self.app_config.create_authors and self.author is None:
-            # TODO: With django-parler 1.8 and Django 1.11 get_or_create() is
-            #       not working with translated fields yet:
-            #       https://github.com/django-parler/django-parler/issues/189
             self.author = Person.objects.get_or_create(
                 user=self.owner,
                 defaults={

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ REQUIREMENTS = [
     'django-cms>=3.4',
     'djangocms-text-ckeditor',
     'django-filer>=0.9.9',
-    'django-parler>=1.4',
+    'django-parler>=1.8.1',
     'django-sortedm2m>=1.2.2,!=1.3.0,!=1.3.1',
     'django-taggit',
     'lxml',


### PR DESCRIPTION
Bump django-parler version to 1.8.1 where they fix issue with
get_or_create.